### PR TITLE
Design: バスメインページUI実装 その他

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:yjg/screens/admin/admin_main.dart';
+import 'package:yjg/screens/bus/bus_main.dart';
+import 'package:yjg/screens/bus/bus_qr.dart';
 import 'package:yjg/screens/restaurant/meal_application.dart';
 import 'package:yjg/screens/restaurant/meal_qr.dart';
 import 'package:yjg/screens/restaurant/menu_list.dart';
 import 'package:yjg/screens/restaurant/restaurant_main.dart';
 import 'package:yjg/screens/dashboard/dashboard_main.dart';
 import 'package:yjg/screens/restaurant/weekend_meal.dart';
+import 'package:yjg/screens/salon/salon_booking.dart';
 import 'package:yjg/screens/salon/salon_main.dart';
 import 'package:yjg/screens/salon/salon_price_list.dart';
 import 'package:yjg/theme/theme.dart';
@@ -44,7 +47,12 @@ class MyApp extends StatelessWidget {
 
         // 미용실 관련
         '/salon_main': (context) => SalonMain(),
-        '/price_list': (context) => SalonPriceList(),
+        '/salon_price_list': (context) => SalonPriceList(),
+        '/salon_booking': (context) => SalonBooking(),
+
+        // 버스 관련
+        '/bus_main': (context) => BusMain(),
+        '/bus_qr':(context) => BusQr(),
 
         //행정 관련
         '/admin_main':(context) => AdminMain(),

--- a/lib/screens/bus/bus_main.dart
+++ b/lib/screens/bus/bus_main.dart
@@ -1,0 +1,121 @@
+import "package:flutter/material.dart";
+import "package:yjg/common/blue_main_rounded_box.dart";
+import "package:yjg/common/notice_box.dart";
+import "package:yjg/common/white_main_rounded_box.dart";
+import "package:yjg/widgets/base_appbar.dart";
+import "package:yjg/widgets/bottom_navigation_bar.dart";
+import "package:yjg/widgets/move_button.dart";
+
+
+class BusMain extends StatelessWidget {
+  const BusMain({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      bottomNavigationBar: const CustomBottomNavigationBar(),
+      appBar: const BaseAppBar(title: '버스'),
+      drawer: Drawer(),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          SizedBox(
+            height: 150.0,
+            child: Stack(
+              children: [
+                BlueMainRoundedBox(),
+                Positioned(
+                  top: 15,
+                  left: 0,
+                  right: 0,
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 12.0),
+                    child: WhiteMainRoundedBox(
+                      iconData: Icons.directions_bus,
+                      mainText: '글로벌캠퍼스',
+                      secondaryText: '탑승인원: 12명(45인승)',
+                      actionText: '위치 변경',
+                      timeText: '14:00',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Container(
+            margin: EdgeInsets.all(20),
+            alignment: Alignment(-0.85, 0.2),
+            child: const Text(
+              '버스 이용하기',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+          ),
+
+          //이동 버튼 배치
+          const Wrap(
+            spacing: 30, // 아이템들 사이의 가로 간격
+            runSpacing: 30, // 아이템들 사이의 세로 간격
+            children: <Widget>[
+              MoveButton(
+                  icon: Icons.schedule,
+                  text1: '시간표',
+                  text2: '버스 시간표 확인',
+                  route: '/bus_schedule'),
+              MoveButton(
+                  icon: Icons.qr_code,
+                  text1: '버스QR',
+                  text2: '버스 탑승 시 QR 찍기',
+                  route: '/bus_qr'),
+            ],
+          ),
+          SizedBox(height: 20),
+          Container(
+            margin: EdgeInsets.all(20),
+            alignment: Alignment(-0.85, 0.2),
+            child: const Text(
+              '버스 공지사항',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+          ),
+          SizedBox(
+            height: 140.0,
+              child: ListView(
+                scrollDirection: Axis.horizontal,
+                children: [
+
+                  // TODO: 나중에 통신(최근 3개만 가져오게 처리)
+                  Padding(
+                    padding: const EdgeInsets.only(
+                        right: 20.0), // 오른쪽에 20픽셀 간격을 줍니다.
+                    child: NoticeBox(
+                      title: '2024년도 1학기 버스 시간표 변경',
+                      content:
+                          '2024년도 1학기 버스 시간표 변동사항을 공지합니다.....',
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(
+                        right: 20.0), // 오른쪽에 20픽셀 간격을 줍니다.
+                    child: NoticeBox(
+                      title: '2024년도 1학기 버스 시간표 변경',
+                      content:
+                          '2024년도 1학기 버스 시간표 변동사항을 공지합니다.....',
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(
+                        right: 20.0), // 오른쪽에 20픽셀 간격을 줍니다.
+                    child: NoticeBox(
+                      title: '2024년도 1학기 버스 시간표 변경',
+                      content:
+                          '2024년도 1학기 버스 시간표 변동사항을 공지합니다.....',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/bus/bus_qr.dart
+++ b/lib/screens/bus/bus_qr.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:yjg/widgets/base_appbar.dart';
+import 'package:yjg/widgets/base_drawer.dart';
+import 'package:yjg/widgets/bottom_navigation_bar.dart';
+import 'package:timer_count_down/timer_count_down.dart';
+
+class BusQr extends StatefulWidget {
+  const BusQr({super.key});
+
+  @override
+  State<BusQr> createState() => _BusQrState();
+}
+
+class _BusQrState extends State<BusQr> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color.fromARGB(255, 29, 127, 159),
+      appBar: BaseAppBar(title: '버스QR'),
+      drawer: const BaseDrawer(),
+      bottomNavigationBar: CustomBottomNavigationBar(),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            margin: EdgeInsets.only(left: 50, right: 50),
+            width: 500,
+            height: 550,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.only(
+                bottomLeft: Radius.circular(20),
+                bottomRight: Radius.circular(20),
+                topRight: Radius.circular(20),
+              ),
+            ),
+            child: Column(
+              children: [
+
+                Container(
+                  margin: EdgeInsets.only(top: 20, bottom: 15,left: 10),
+                  child: Row(
+                    children: [
+                      //뒤로가기 버튼
+                      IconButton(
+                        onPressed: () {
+                          Navigator.pop(context);
+                        },
+                        icon: Icon(Icons.keyboard_return),
+                        color: const Color.fromARGB(255, 29, 127, 159),
+                      ),
+                      SizedBox(
+                        width: 40,
+                      ),
+
+                      //식당 QR코드 글자
+                      Text(
+                        '식당 QR 코드',
+                        style: TextStyle(
+                          color: const Color.fromARGB(255, 29, 127, 159),
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                //~~~글자
+                Container(
+                  margin: EdgeInsets.only(bottom: 15),
+                  child: Text(
+                    '버스 탑승 시 단말기에 QR 코드를 찍어주세요.',
+                    style: TextStyle(fontSize: 12),
+                  ),
+                ),
+
+                //카운트 다운
+                Countdown(
+                  seconds: 15,
+                  build: (_, double time) => Text(
+                    time.toInt().toString(),
+                    style: TextStyle(
+                      fontSize: 35,
+                    ),
+                  ),
+                  onFinished: () {
+                    Navigator.pop(context);
+                  },
+                ),
+
+                //QR여기에 넣기
+                Container(
+                  width: 220,
+                  height: 220,
+                  color: Colors.black,
+                ),
+
+
+                //구분 점선
+                Container(
+                  margin: const EdgeInsets.only(top: 10, bottom: 10),
+                  child: const Text(
+                      '............................................................',
+                      style:
+                          TextStyle(color: Color.fromARGB(255, 173, 173, 173))),
+                ),
+
+                //학번 글자
+                Text('1901201',style: TextStyle(
+                  color: Color.fromARGB(255, 148, 148, 148),
+                  fontSize: 15
+                ),),
+
+                //이름 글자
+                Text('이민혁',style: TextStyle(
+                  color: Color.fromARGB(255, 0, 0, 0),
+                  fontSize: 23,
+                  fontWeight: FontWeight.bold
+                ),),
+
+                //학과 글자
+                Text('컴퓨터정보계열',style: TextStyle(
+                  color: Color.fromARGB(255, 29, 127, 159),
+                  fontSize: 15
+                ),),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/salon/salon_main.dart
+++ b/lib/screens/salon/salon_main.dart
@@ -14,6 +14,7 @@ class SalonMain extends StatelessWidget {
     return Scaffold(
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '미용실'),
+      drawer: Drawer(),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [


### PR DESCRIPTION
## 📣 연관된 이슈
> ex) closes #31, #32 

## 📝 작업 내용
> 1. バスページ関連のルーターを正義しました。
버스 페이지 관련 라우터를 정의했습니다.
> 2. バスメインページのUIを実装しました。
버스 메인페이지의 UI를 구현하였습니다.
> 3. バスQRページのUIを実装しました。
버스 QR페이지의 UI를 구현하였습니다.
> 4. 美容室メインページでドロワーを追加しました。
미용실 메인페이지에 drawer를 추가하였습니다.


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
