### PR TITLE
Feat: トップスクロールを防ぐためのCustomSingleChildScrollViewウィジェットの実装

### DIFF
--- a/lib/administration/presentaion/pages/admin_main.dart
+++ b/lib/administration/presentaion/pages/admin_main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yjg/shared/widgets/CustomSingleChildScrollView.dart';
 import 'package:yjg/shared/widgets/blue_main_rounded_box.dart';
 import 'package:yjg/shared/widgets/white_main_rounded_box.dart';
 import 'package:yjg/shared/theme/palette.dart';
@@ -24,7 +25,7 @@ class _AdminMainState extends State<AdminMain> {
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '행정'),
       drawer: const BaseDrawer(),
-      body: SingleChildScrollView(
+      body: CustomSingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [

--- a/lib/administration/presentaion/pages/meeting_room.dart
+++ b/lib/administration/presentaion/pages/meeting_room.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:yjg/administration/presentaion/widget/meeting_room_card.dart';
 import 'package:yjg/administration/presentaion/widget/meeting_room_time.dart';
+import 'package:yjg/shared/widgets/CustomSingleChildScrollView.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
 import 'package:yjg/shared/widgets/blue_main_rounded_box.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
@@ -39,7 +40,7 @@ class _MeetingRoomState extends State<MeetingRoom> {
       appBar: BaseAppBar(title: "회의실 예약"),
       bottomNavigationBar: const CustomBottomNavigationBar(),
       drawer: const Drawer(),
-      body: SingleChildScrollView(
+      body: CustomSingleChildScrollView(
         child: Column(
           children: [
             //겹쳐진 박스

--- a/lib/administration/presentaion/pages/sleepover_application.dart
+++ b/lib/administration/presentaion/pages/sleepover_application.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yjg/shared/widgets/CustomSingleChildScrollView.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
 import 'package:yjg/shared/widgets/base_drawer.dart';
 
@@ -20,7 +21,7 @@ class _SleepoverApplicationState extends State<SleepoverApplication> {
     return Scaffold(
       appBar: const BaseAppBar(title: '외박/외출'),
       drawer: const BaseDrawer(),
-      body: SingleChildScrollView(
+      body: CustomSingleChildScrollView(
         child: Column(
           children: [
             Column(

--- a/lib/restaurant/presentaion/pages/meal_application.dart
+++ b/lib/restaurant/presentaion/pages/meal_application.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:group_button/group_button.dart';
+import 'package:yjg/shared/widgets/CustomSingleChildScrollView.dart';
 import 'package:yjg/shared/widgets/blue_main_rounded_box.dart';
 import 'package:yjg/shared/widgets/white_main_rounded_box.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
@@ -31,7 +32,7 @@ class _MealApplicationState extends State<MealApplication> {
         appBar: const BaseAppBar(title: '식수 신청'),
         drawer: const BaseDrawer(),
         bottomNavigationBar: CustomBottomNavigationBar(),
-        body: SingleChildScrollView(
+        body: CustomSingleChildScrollView(
           child: Column(
             children: [
               //상단 겹쳐져 있는 바

--- a/lib/restaurant/presentaion/pages/restaurant_main.dart
+++ b/lib/restaurant/presentaion/pages/restaurant_main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yjg/shared/widgets/CustomSingleChildScrollView.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
 import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
@@ -22,7 +23,7 @@ class _RestaurantMainState extends State<RestaurantMain> {
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '식수'),
       drawer: const BaseDrawer(),
-      body: SingleChildScrollView(
+      body: CustomSingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [

--- a/lib/restaurant/presentaion/pages/weekend_meal.dart
+++ b/lib/restaurant/presentaion/pages/weekend_meal.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yjg/shared/widgets/CustomSingleChildScrollView.dart';
 import 'package:yjg/shared/widgets/blue_main_rounded_box.dart';
 import 'package:yjg/shared/widgets/white_main_rounded_box.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
@@ -32,7 +33,7 @@ class _WeekendMealState extends State<WeekendMeal> {
         appBar: BaseAppBar(title: '주말식수'),
         drawer: const BaseDrawer(),
         bottomNavigationBar: CustomBottomNavigationBar(),
-        body: SingleChildScrollView(
+        body: CustomSingleChildScrollView(
           child: Column(
             children: [
               //상단 겹쳐져 있는 바

--- a/lib/salon(admin)/domain/usecases/calendar_builders_weekday.dart
+++ b/lib/salon(admin)/domain/usecases/calendar_builders_weekday.dart
@@ -1,0 +1,3 @@
+
+import 'package:flutter/material.dart';
+

--- a/lib/salon(admin)/presentation/pages/admin_salon_main.dart
+++ b/lib/salon(admin)/presentation/pages/admin_salon_main.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:yjg/salon(admin)/presentation/widgets/main_rounded_box.dart";
 import "package:yjg/salon(admin)/presentation/widgets/main_rounded_box_s.dart";
 import "package:yjg/shared/theme/palette.dart";
+import "package:yjg/shared/widgets/CustomSingleChildScrollView.dart";
 import "package:yjg/shared/widgets/base_appbar.dart";
 import "package:yjg/shared/widgets/blue_main_rounded_box.dart";
 import "package:yjg/shared/widgets/bottom_navigation_bar.dart";
@@ -15,7 +16,7 @@ class AdminSalonMain extends StatelessWidget {
     return Scaffold(
       appBar: const BaseAppBar(title: "미용실"),
       bottomNavigationBar: const CustomBottomNavigationBar(),
-      body: SingleChildScrollView(
+      body: CustomSingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [

--- a/lib/shared/widgets/CustomSingleChildScrollView.dart
+++ b/lib/shared/widgets/CustomSingleChildScrollView.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class CustomSingleChildScrollView extends StatelessWidget {
+  final Widget child;
+
+  const CustomSingleChildScrollView({Key? key, required this.child}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      physics: ClampingScrollPhysics(), // 사용자가 스크롤을 안 한 상태(가장 상단)에 있을 때 스크롤을 막아준다
+      child: child,
+    );
+  }
+}
+
+


### PR DESCRIPTION
## 📣 연관된 이슈
> X

## 📝 작업 내용
> - アプバーの直下に位置するウィジェットがあり、画面の上部にいる場合（スクロールしていない場合）に上にスクロールできないようにするために、CustomSingleChildScrollViewを作成しました。
appbar의 바로 밑에 위치하고 있는 위젯이 있어, 화면 상단에 있을 경우(스크롤을 하지 않았을 경우)에는 위로 스크롤을 하는 것을 방지하고자, CustomSingleChildScrollView를 만들었습니다.

> - このウィジェットを適用すると、画面の上部では上にスクロールが防止され、下にスクロールした時点で上にスクロールできるようになります。
해당 위젯을 적용하면, 상단에 있을 경우 위쪽 스크롤이 방지되고, 아래로 스크롤한 시점부터 위로 스크롤 할 수 있도록 활성화됩니다.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
