### PR TITLE
Design: 予約管理ページのUI実装

### DIFF
--- a/lib/salon(admin)/presentation/pages/admin_salon_booking.dart
+++ b/lib/salon(admin)/presentation/pages/admin_salon_booking.dart
@@ -1,0 +1,32 @@
+import "package:flutter/material.dart";
+import "package:yjg/shared/widgets/base_appbar.dart";
+import 'package:yjg/salon(admin)/presentation/widgets/booking_calendar.dart';
+import "package:yjg/shared/widgets/bottom_navigation_bar.dart";
+
+class AdminSalonBooking extends StatelessWidget {
+  const AdminSalonBooking({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const BaseAppBar(title: "예약 관리"),
+      bottomNavigationBar: const CustomBottomNavigationBar(),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Container(
+              margin: EdgeInsets.only(top: 20),
+              alignment: Alignment(-0.85, 0.2),
+              child: const Text(
+                '예약 날짜 선택',
+                style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold),
+              ),
+            ),
+            BookingCalendar(),
+            SizedBox(height: 20),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/salon(admin)/presentation/pages/admin_salon_main.dart
+++ b/lib/salon(admin)/presentation/pages/admin_salon_main.dart
@@ -71,13 +71,37 @@ class AdminSalonMain extends StatelessWidget {
             SizedBox(
               height: 20.0,
             ),
-            Container(
-              margin: EdgeInsets.all(20),
-              alignment: Alignment(-0.85, 0.2),
-              child: const Text(
-                '미승인 예약(최근 3건)',
-                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-              ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                Container(
+                  margin: EdgeInsets.only(left: 40),
+                  child: const Text(
+                    '미승인 예약(최근 3건)',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                  ),
+                ),
+                const Spacer(),
+                Padding(
+                  padding: EdgeInsets.only(right: 20.0, top: 5.0),
+                  child: TextButton(
+                    onPressed: () => {},
+                    style: ButtonStyle(
+                      overlayColor: MaterialStateProperty.all(
+                        Palette.stateColor4.withOpacity(0.1),
+                      ),
+                    ),
+                    child: const Text(
+                      "더보기",
+                      style: TextStyle(
+                          color: Palette.stateColor4,
+                          fontSize: 13.0,
+                          fontWeight: FontWeight.bold,
+                          letterSpacing: -0.2),
+                    ),
+                  ),
+                ),
+              ],
             ),
 
             // TODO: 하드 코딩(일단 3건만 볼 수 있도록 하기)
@@ -87,22 +111,9 @@ class AdminSalonMain extends StatelessWidget {
                   bookText: "고속도로컷",
                   time: "24/02/15 16시",
                   iconColor: Palette.stateColor1),
-
-            TextButton(
-                onPressed: () => {},
-                style: ButtonStyle(
-                  overlayColor: MaterialStateProperty.all(
-                    Palette.stateColor4.withOpacity(0.1),
-                  ),
-                ),
-                child: Text(
-                  "더보기",
-                  style: TextStyle(
-                      color: Palette.stateColor4,
-                      fontSize: 13.0,
-                      fontWeight: FontWeight.bold,
-                      letterSpacing: -0.2),
-                ))
+            SizedBox(
+              height: 20.0,
+            ),
           ],
         ),
       ),

--- a/lib/salon(admin)/presentation/widgets/booking_box.dart
+++ b/lib/salon(admin)/presentation/widgets/booking_box.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:yjg/shared/theme/palette.dart';
+
+enum BookingAction { confirm, reject }
+
+class BookingBox extends StatelessWidget {
+  final String bookText;
+  final String time;
+
+  const BookingBox({
+    super.key,
+    required this.bookText,
+    required this.time,
+  });
+
+  void _showBookingActionModal(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (BuildContext context) {
+        BookingAction? _selectedAction = BookingAction.confirm; // 기본값 설정
+        return StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Container(
+              padding: EdgeInsets.all(20),
+              child: Wrap(
+                children: <Widget>[
+                  Padding(
+                    padding: EdgeInsets.only(top: 20.0, bottom: 20.0),
+                    child: Text(
+                      '해당 예약건을 어떻게 하시겠습니까?',
+                      style:
+                          TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  ListTile(
+                    title: const Text('승인하기'),
+                    leading: Radio<BookingAction>(
+                      value: BookingAction.confirm,
+                      activeColor: Palette.mainColor,
+                      groupValue: _selectedAction,
+                      onChanged: (BookingAction? value) {
+                        setState(() => _selectedAction = value);
+                      },
+                    ),
+                  ),
+                  ListTile(
+                    title: const Text('거절하기'),
+                    leading: Radio<BookingAction>(
+                      value: BookingAction.reject,
+                      groupValue: _selectedAction,
+                      onChanged: (BookingAction? value) {
+                        setState(() => _selectedAction = value);
+                      },
+                    ),
+                  ),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: ElevatedButton(
+                      onPressed: () {
+                        // 완료 버튼 로직
+                        Navigator.pop(context);
+                      },
+                      child: Text(
+                        '완료',
+                        style: TextStyle(color: Colors.white),
+                      ),
+                      style: ElevatedButton.styleFrom(
+                          backgroundColor: Palette.mainColor),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => _showBookingActionModal(context),
+      child: Center(
+        child: Container(
+          padding: EdgeInsets.symmetric(horizontal: 16.0),
+          margin: EdgeInsets.symmetric(vertical: 7.0),
+          height: 70.0,
+          width: MediaQuery.of(context).size.width * 0.85,
+          decoration: BoxDecoration(
+            color: Palette.backgroundColor,
+            borderRadius: BorderRadius.circular(10.0),
+            border: Border.all(
+              color: Colors.grey.shade300,
+              width: 1.0,
+            ),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                bookText,
+                style: TextStyle(color: Palette.textColor, fontSize: 15),
+              ),
+              Text(
+                time,
+                style: TextStyle(color: Palette.stateColor1, fontSize: 14),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/salon(admin)/presentation/widgets/booking_calendar.dart
+++ b/lib/salon(admin)/presentation/widgets/booking_calendar.dart
@@ -1,0 +1,239 @@
+import 'dart:collection';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:table_calendar/table_calendar.dart';
+import 'package:yjg/salon(admin)/presentation/widgets/booking_box.dart';
+import 'package:yjg/shared/theme/palette.dart';
+
+class BookingCalendar extends StatefulWidget {
+  @override
+  _BookingCalendarState createState() => _BookingCalendarState();
+}
+
+class _BookingCalendarState extends State<BookingCalendar> {
+  CalendarFormat _calendarFormat = CalendarFormat.month;
+  DateTime _focusedDay = DateTime.now();
+  DateTime? _selectedDay;
+  Map<DateTime, List> _eventsList = {};
+  String? _selectedStatus;
+  int getHashCode(DateTime key) {
+    return key.day * 1000000 + key.month * 10000 + key.year;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDay = _focusedDay;
+    _eventsList = {
+      DateTime.now().subtract(Duration(days: 2)): ['매직펌_김정원', '물결펌_김정원'],
+      DateTime.now(): ['물결펌_김정원', '매직펌_김정원', '셋팅펌_김정원', '레이어드컷_김정원'],
+      DateTime.now().add(Duration(days: 1)): [
+        '매직펌_김정원',
+        '레이어드컷_김정원',
+        '매직펌_김정원',
+        '셋팅펌_김정원'
+      ],
+      DateTime.now().add(Duration(days: 3)):
+          Set.from(['물결펌_김정원', '매직펌_김정원', '셋팅펌_김정원', '레이어드컷_김정원']).toList(),
+      DateTime.now().add(Duration(days: 7)): [
+        '셋팅펌_김정원',
+        '레이어드컷_김정원',
+        '매직펌_김정원'
+      ],
+      DateTime.now().add(Duration(days: 11)): ['셋팅펌_김정원', '매직펌_김정원'],
+      DateTime.now().add(Duration(days: 17)): [
+        '셋팅펌_김정원',
+        '레이어드컷_김정원',
+        '단발컷_김정원',
+        '물결펌_김정원'
+      ],
+      DateTime.now().add(Duration(days: 22)): ['셋팅펌_김정원', '매직펌_김정원'],
+      DateTime.now().add(Duration(days: 26)): [
+        '레이어드컷_김정원',
+        '매직펌_김정원',
+        '앞머리컷_김정원'
+      ],
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final _events = LinkedHashMap<DateTime, List>(
+      equals: isSameDay,
+      hashCode: getHashCode,
+    )..addAll(_eventsList);
+
+    List _getEventForDay(DateTime day) {
+      return _events[day] ?? [];
+    }
+
+    return Column(
+      children: [
+        TableCalendar(
+          locale: 'ko_KR',
+          firstDay: DateTime.utc(2020, 1, 1),
+          lastDay: DateTime.utc(2030, 12, 31),
+          headerStyle: HeaderStyle(
+            titleCentered: false,
+            titleTextFormatter: (date, locale) =>
+                DateFormat.yMMMMd(locale).format(date),
+            formatButtonVisible: false,
+
+            leftChevronVisible: false, // 왼쪽 화살표 버튼 숨깁.
+            rightChevronVisible: false, // 오른쪽 화살표 버튼 숨깁.
+            headerMargin: EdgeInsets.only(bottom: 20.0, top: 20.0, left: 20.0),
+            titleTextStyle: const TextStyle(
+              fontSize: 15.0,
+              color: Palette.textColor,
+            ),
+            headerPadding: const EdgeInsets.symmetric(vertical: 4.0),
+          ),
+          focusedDay: _focusedDay,
+          eventLoader: _getEventForDay,
+          calendarBuilders: CalendarBuilders(
+            markerBuilder: (context, day, events) {
+              if (events.isNotEmpty) {
+                return Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Container(
+                    margin: const EdgeInsets.only(bottom: 1),
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: Palette.stateColor1,
+                    ),
+                    width: 5.0,
+                    height: 5.0,
+                  ),
+                );
+              }
+            },
+            dowBuilder: (context, day) {
+              // 요일 표시(주말 색상 변경)
+              switch (day.weekday) {
+                case 1:
+                  return Center(
+                    child: Text('월'),
+                  );
+                case 2:
+                  return Center(
+                    child: Text('화'),
+                  );
+                case 3:
+                  return Center(
+                    child: Text('수'),
+                  );
+                case 4:
+                  return Center(
+                    child: Text('목'),
+                  );
+                case 5:
+                  return Center(
+                    child: Text('금'),
+                  );
+                case 6:
+                  return Center(
+                    child: Text(
+                      '토',
+                      style: TextStyle(color: Palette.stateColor1),
+                    ),
+                  );
+                case 7:
+                  return Center(
+                    child: Text(
+                      '일',
+                      style: TextStyle(color: Palette.stateColor3),
+                    ),
+                  );
+              }
+            },
+          ),
+          calendarFormat: _calendarFormat,
+          onFormatChanged: (format) {
+            if (_calendarFormat != format) {
+              setState(() {
+                _calendarFormat = format;
+              });
+            }
+          },
+          selectedDayPredicate: (day) {
+            return isSameDay(_selectedDay, day);
+          },
+          onDaySelected: (selectedDay, focusedDay) {
+            if (!isSameDay(_selectedDay, selectedDay)) {
+              setState(() {
+                _selectedDay = selectedDay;
+                _focusedDay = focusedDay;
+              });
+              _getEventForDay(selectedDay);
+            }
+          },
+          onPageChanged: (focusedDay) {
+            _focusedDay = focusedDay;
+          },
+        ),
+        Padding(
+          padding: EdgeInsets.only(left: 20.0, top: 30.0, bottom: 15.0),
+          child: Align(
+            alignment: Alignment.bottomLeft,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                Text(
+                  "예약 목록",
+                  style: TextStyle(fontSize: 17.0),
+                ),
+                Spacer(),
+                Padding(
+                  padding: EdgeInsets.only(right: 25.0),
+                  child: DropdownButton<String>(
+                    value: _selectedStatus,
+                    icon: SizedBox.shrink(),
+                    hint: Text("상태 선택",
+                        style: TextStyle(
+                            fontSize: 14.0,
+                            color: Palette.mainColor,
+                            letterSpacing: -1)),
+                    underline: Container(
+                      height: 0,
+                    ),
+                    items: <String>["접수상태", "승인상태", "거절상태"]
+                        .map<DropdownMenuItem<String>>((String value) {
+                      return DropdownMenuItem<String>(
+                        value: value,
+                        child: Text(
+                          value,
+                          style: TextStyle(
+                              color: Palette.textColor,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 13.0,
+                              letterSpacing: -0.2),
+                        ),
+                      );
+                    }).toList(),
+                    onChanged: (String? newValue) {
+                      setState(() {
+                        _selectedStatus = newValue;
+                      });
+                    },
+                  ),
+                )
+              ],
+            ),
+          ),
+        ),
+        ListView(
+          shrinkWrap: true,
+          children: _getEventForDay(_selectedDay!)
+              .map((event) => ListTile(
+                    title: BookingBox(
+                      bookText: event,
+                      time: "13:00",
+                    ),
+                  ))
+              .toList(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/salon/presentaion/pages/salon_booking.dart
+++ b/lib/salon/presentaion/pages/salon_booking.dart
@@ -1,6 +1,6 @@
 import 'package:dotted_line/dotted_line.dart';
 import 'package:flutter/material.dart';
-import 'package:yjg/salon/presentaion/widgets/booking_calendar.dart';
+import 'package:yjg/salon(admin)/presentation/widgets/booking_calendar.dart';
 import 'package:yjg/salon/presentaion/widgets/booking_next_button.dart';
 import 'package:yjg/salon/presentaion/widgets/date_button.dart';
 import 'package:yjg/shared/theme/palette.dart';


### PR DESCRIPTION
## 📣 연관된 이슈
> #61 

## 📝 작업 내용
> 1. 予約管理ページのUIを実装しました。（管理者向け） 예약 관리 페이지 UI를 구현했습니다.
> 2. 美容室管理者メインページの「もっと見る」ボタンの位置を変更しました。 미용실 관리자 메인 페이지의 더보기 버튼의 위치를 변경했습니다.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
