### PR TITLE
Design: 美容院の価格表ページのUI実装(管理者向け) 

### DIFF
--- a/lib/salon(admin)/presentation/pages/admin_salon_main.dart
+++ b/lib/salon(admin)/presentation/pages/admin_salon_main.dart
@@ -85,7 +85,8 @@ class AdminSalonMain extends StatelessWidget {
                 Padding(
                   padding: EdgeInsets.only(right: 20.0, top: 5.0),
                   child: TextButton(
-                    onPressed: () => {},
+                    onPressed: () => {
+                      Navigator.pushNamed(context, '/admin_salon_booking'),},
                     style: ButtonStyle(
                       overlayColor: MaterialStateProperty.all(
                         Palette.stateColor4.withOpacity(0.1),

--- a/lib/salon(admin)/presentation/pages/admin_salon_price_list.dart
+++ b/lib/salon(admin)/presentation/pages/admin_salon_price_list.dart
@@ -1,0 +1,17 @@
+import "package:flutter/material.dart";
+import "package:yjg/salon(admin)/presentation/widgets/service_tabbar.dart";
+import "package:yjg/shared/widgets/base_appbar.dart";
+import "package:yjg/shared/widgets/bottom_navigation_bar.dart";
+
+class AdminSalonPriceList extends StatelessWidget {
+  const AdminSalonPriceList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const BaseAppBar(title: "가격표 관리"),
+      bottomNavigationBar: const CustomBottomNavigationBar(),
+      body: ServiceTabbar(),
+    );
+  }
+}

--- a/lib/salon(admin)/presentation/widgets/booking_box.dart
+++ b/lib/salon(admin)/presentation/widgets/booking_box.dart
@@ -65,7 +65,9 @@ class BookingBox extends StatelessWidget {
                         style: TextStyle(color: Colors.white),
                       ),
                       style: ElevatedButton.styleFrom(
-                          backgroundColor: Palette.mainColor),
+                        backgroundColor: Palette.mainColor,
+                        elevation: 0,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/salon(admin)/presentation/widgets/edit_service_modal.dart
+++ b/lib/salon(admin)/presentation/widgets/edit_service_modal.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:yjg/shared/theme/palette.dart';
+
+void editServiceModal(BuildContext context, Map<String, dynamic> service) {
+  TextEditingController _nameController =
+      TextEditingController(text: service['name']);
+  TextEditingController _priceController =
+      TextEditingController(text: service['price'].toString());
+
+  showModalBottomSheet(
+    context: context,
+    builder: (BuildContext context) {
+      return Container(
+        padding: EdgeInsets.all(20.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              '서비스 수정',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 20),
+            TextField(
+              controller: _nameController,
+              decoration: InputDecoration(
+                labelText: '서비스명',
+              ),
+            ),
+            SizedBox(height: 20),
+            TextField(
+              controller: _priceController,
+              decoration: InputDecoration(labelText: '가격'),
+              keyboardType: TextInputType.number,
+            ),
+            SizedBox(height: 20),
+            Row(
+              mainAxisAlignment:
+                  MainAxisAlignment.spaceBetween, // 버튼들 사이에 공간을 최대한 분배
+              children: [
+                TextButton(
+                  child: Text(
+                    '서비스 삭제',
+                    style: TextStyle(
+                        color: Palette.stateColor3,
+                        letterSpacing: -1.0,
+                        fontWeight: FontWeight.bold),
+                  ),
+                  onPressed: () {
+                    // 삭제 로직 구현
+                    Navigator.pop(context); // 모달 닫기
+                  },
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    // 완료 버튼 로직
+                    Navigator.pop(context);
+                  },
+                  child: Text(
+                    '완료',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Palette.mainColor,
+                    elevation: 0, // 쉐도우 제거
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 30)
+          ],
+        ),
+      );
+    },
+  );
+}

--- a/lib/salon(admin)/presentation/widgets/service_tabbar.dart
+++ b/lib/salon(admin)/presentation/widgets/service_tabbar.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:yjg/salon(admin)/presentation/widgets/edit_service_modal.dart';
+import 'package:yjg/shared/theme/palette.dart';
+
+class ServiceTabbar extends StatefulWidget {
+  @override
+  _ServiceTabbar createState() => _ServiceTabbar();
+}
+
+class _ServiceTabbar extends State<ServiceTabbar>
+    with SingleTickerProviderStateMixin {
+  TabController? _tabController;
+  final List<Map<String, dynamic>> _cutServices = [
+    {"name": "컷트(남)", "price": 10000},
+    {"name": "재학생(남)", "price": 10000},
+    {"name": "컷트+옆다운(남)", "price": 15000},
+    {"name": "컷트+옆다운+뒷다운(남)", "price": 20000},
+    {"name": "컷트+전체다운(남)", "price": 25000},
+    {"name": "면접헤어(남)", "price": 10000},
+    {"name": "앞머리(여)", "price": 2000},
+    {"name": "단발컷(여)", "price": 8000},
+    {"name": "숏컷(여)", "price": 10000},
+    {"name": "디자인컷(여)", "price": 10000},
+    {"name": "레이어드컷(여)", "price": 10000},
+    {"name": "허쉬컷(여)", "price": 10000},
+    {"name": "보브단발(여)", "price": 10000},
+  ];
+
+  final List<Map<String, dynamic>> _permServices = [
+    {"name": "컷트+댄디펌(남)", "price": 30000},
+    {"name": "컷트+애즈펌(남)", "price": 30000},
+    {"name": "컷트+쉐도우펌(남)", "price": 30000},
+    {"name": "컷트+포마드펌(남)", "price": 30000},
+    {"name": "컷트+리프펌(남)", "price": 35000},
+    {"name": "컷트+스왈로펌(남)", "price": 40000},
+    {"name": "컷트+펌+옆다운(남)", "price": 35000},
+    {"name": "컷트+펌+옆+뒷다운(남)", "price": 40000},
+    {"name": "컷트+볼륨매직(남)", "price": 45000},
+    {"name": "재학생 외 펌(남)", "price": 35000},
+    {"name": "단발펌(여)", "price": 40000},
+    {"name": "매직(여)", "price": 50000},
+    {"name": "디지털(여)", "price": 55000},
+    {"name": "볼륨매직(여)", "price": 60000},
+    {"name": "물결펌(여)", "price": 60000},
+    {"name": "매직셋팅(여)", "price": 70000},
+  ];
+
+  final List<Map<String, dynamic>> _colorServices = [
+    {"name": "컷트(남)", "price": 10000},
+    {"name": "재학생(남)", "price": 10000},
+    {"name": "컷트+옆다운(남)", "price": 15000},
+    {"name": "컷트+옆다운+뒷다운(남)", "price": 20000},
+    {"name": "컷트+전체다운(남)", "price": 25000},
+    {"name": "면접헤어(남)", "price": 10000},
+    {"name": "앞머리(여)", "price": 2000},
+    {"name": "단발컷(여)", "price": 8000},
+    {"name": "숏컷(여)", "price": 10000},
+    {"name": "디자인컷(여)", "price": 10000},
+    {"name": "레이어드컷(여)", "price": 10000},
+    {"name": "허쉬컷(여)", "price": 10000},
+    {"name": "보브단발(여)", "price": 10000},
+  ];
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController?.dispose();
+    super.dispose();
+  }
+
+  Widget _buildServiceList(List<Map<String, dynamic>> services) {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width * 0.93,
+      child: ListView.builder(
+        itemCount: services.length,
+        padding: EdgeInsets.only(top: 15.0),
+        itemBuilder: (context, index) {
+          final service = services[index];
+          return InkWell(
+            onTap: () => editServiceModal(context, service),
+            child: Container(
+              padding: EdgeInsets.symmetric(horizontal: 30.0),
+              margin: EdgeInsets.symmetric(vertical: 7.0),
+              height: 70.0,
+              decoration: BoxDecoration(
+                color: Palette.backgroundColor,
+                borderRadius: BorderRadius.circular(10.0),
+                border: Border.all(
+                  color: Colors.grey.shade300,
+                  width: 1.0,
+                ),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    service['name'],
+                    style: TextStyle(
+                      fontSize: 16.0,
+                    ),
+                  ),
+                  Text(
+                    '${service['price']}원',
+                    style: TextStyle(color: Palette.mainColor),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 3,
+      child: Column(
+        children: <Widget>[
+          TabBar(
+            controller: _tabController,
+            tabs: [
+              Tab(text: '컷트'),
+              Tab(text: '펌'),
+              Tab(text: '염색'),
+            ],
+          ),
+          SizedBox(height: 20.0),
+          Text(
+            '항목을 선택하면 수정이 가능합니다.',
+            style: TextStyle(color: Palette.stateColor3),
+          ),
+          SizedBox(height: 10.0),
+          Expanded(
+            child: TabBarView(
+              controller: _tabController,
+              children: [
+                Align(
+                  alignment: Alignment.topCenter,
+                  child: _buildServiceList(_cutServices),
+                ),
+                Align(
+                  alignment: Alignment.topCenter,
+                  child: _buildServiceList(_permServices),
+                ),
+                Align(
+                  alignment: Alignment.topCenter,
+                  child: _buildServiceList(_colorServices),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 📣 연관된 이슈
> #62 

## 📝 작업 내용
> 1. 価格表ページのUIを実装しました。（管理者向け） 관리자용 가격표 페이지 UI를 구현했습니다.
> 2. admin_salon_mainにあるボタンのonPressedにNavigatorを追加しました。 admin_salon_main에 위치한 버튼의 onPressed에 네비게이터를 추가하였습니다. 
> 3. admin_salon_mainにあるボタンのスタイルを修正しました。 admin_salon_main에 있는 버튼의 스타일을 변경하였습니다.


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
