### PR TITLE
Feat: 会員登録ページ(語学堂学生用)API通信ロジックの実装

### DIFF
--- a/lib/auth/data/data_resources/register_data_source.dart
+++ b/lib/auth/data/data_resources/register_data_source.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:yjg/auth/presentation/viewmodels/user_viewmodel.dart';
+import 'package:yjg/shared/constants/api_url.dart';
+
+// 회원가입 통신
+
+class RegisterDataSource {
+  Future<http.Response> postRegisterAPI(WidgetRef ref) async {
+
+    // state 값 가져오기
+    final registerState = ref.read(userProvider.notifier);
+ final body = jsonEncode(<String, String>{
+        'email': registerState.email,
+        'password': registerState.password,
+        'name': registerState.name,
+        'phone_number': registerState.phoneNumber,
+      });
+
+    // 통신
+    final response = await http.post(
+      Uri.parse('$apiURL/api/user/foreigner'),
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+      },
+
+     
+      // state 값을 json 형태로 변환
+      body: jsonEncode(<String, String>{
+        'email': registerState.email,
+        'password': registerState.password,
+        'name': registerState.name,
+        'phone_number': registerState.phoneNumber,
+      }),
+
+
+    );
+      print(body);
+
+    // status code가 200이 아닐 경우
+    if (response.statusCode != 201) {
+      throw Exception('회원가입 실패: ${response.statusCode}');
+    }
+    
+    print(response.body);
+    return response;
+  }
+}

--- a/lib/auth/domain/usecases/register_usecase.dart
+++ b/lib/auth/domain/usecases/register_usecase.dart
@@ -1,0 +1,71 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/auth/data/data_resources/register_data_source.dart';
+import 'package:yjg/auth/presentation/viewmodels/user_viewmodel.dart';
+import 'package:yjg/shared/theme/theme.dart';
+
+class RegisterUseCase {
+  final WidgetRef ref;
+
+  RegisterUseCase({required this.ref});
+
+  Future<void> execute({
+    required String email,
+    required String password,
+    required String name,
+    required String phoneNumber,
+    required BuildContext context,
+  }) async {
+    // User 상태 업데이트를 위해 userProvider를 통해 User 인스턴스에 접근
+    ref.read(userProvider.notifier).registerFormUpdate(
+          email: email,
+          password: password,
+          name: name,
+          phoneNumber: phoneNumber,
+        );
+
+    // 회원가입 로직 구현
+    try {
+      await RegisterDataSource().postRegisterAPI(ref);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content: Text('회원가입에 성공하였습니다.'),
+            backgroundColor: Palette.mainColor),
+      );
+      // 성공 시 로그인 페이지로 이동
+      Navigator.pushNamed(context, '/login_domestic');
+    } catch (e) {
+      // 회원가입 실패 시 에러 메시지 표시
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('회원가입에 실패하였습니다. 다시 시도해 주세요. 에러: $e'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+}
+
+class PhoneNumberInputFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+      TextEditingValue oldValue, TextEditingValue newValue) {
+    final newText = newValue.text.replaceAll(RegExp(r'\D'), '');
+    if (newText.length <= 3)
+      return TextEditingValue(
+          text: newText,
+          selection: TextSelection.collapsed(offset: newText.length));
+    if (newText.length <= 7)
+      return TextEditingValue(
+          text: '${newText.substring(0, 3)}-${newText.substring(3)}',
+          selection: TextSelection.collapsed(offset: newText.length + 1));
+    return TextEditingValue(
+      text:
+          '${newText.substring(0, 3)}-${newText.substring(3, 7)}-${newText.substring(7)}',
+      selection: TextSelection.collapsed(offset: min(newText.length + 2, 13)),
+    );
+  }
+}

--- a/lib/auth/presentation/pages/international_registration.dart
+++ b/lib/auth/presentation/pages/international_registration.dart
@@ -95,12 +95,16 @@ class InternationalRegisteration extends ConsumerWidget {
                                 final registerUseCase = RegisterUseCase(
                                     ref: ref); // RegisterUseCase 인스턴스 생성
 
+                                // 전화번호 입력값에서 숫자만 추출
+                                String phoneNumber = phoneNumberController.text
+                                    .replaceAll(RegExp(r'[^\d]'), '');
+
                                 // execute 메소드를 비동기적으로 호출하고, 사용자 입력을 전달
                                 await registerUseCase.execute(
                                   email: emailController.text,
                                   password: passwordController.text,
                                   name: nameController.text,
-                                  phoneNumber: phoneNumberController.text,
+                                  phoneNumber: phoneNumber,
                                   context: context,
                                 );
                               } else {


### PR DESCRIPTION
## 📣 연관된 이슈
> #59 

## 📝 작업 내용
> 会員登録ページ(語学堂学生用)API通信ロジックを実装しました。（+ ユースケース、データソース、会員登録ボタンのロジック）
회원가입 페이지(어학당 학생용) API 통신 로직을 구현하였습니다. (+ usecase, datasource, 회원가입 버튼 클릭 시 로직 처리)

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
