### PR TITLE
Feat: 画像ビュースワイプ機能追加

### DIFF
--- a/lib/shared/widgets/as_image_view.dart
+++ b/lib/shared/widgets/as_image_view.dart
@@ -25,8 +25,8 @@ class AsImageView extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                    builder: (context) =>
-                        AsImageViewDetail(imageUrl: imageUrls[index])),
+                  builder: (context) => AsImageViewDetail(imageUrls: imageUrls),
+                ),
               );
             },
             child: Padding(

--- a/lib/shared/widgets/as_image_view_detail.dart
+++ b/lib/shared/widgets/as_image_view_detail.dart
@@ -1,22 +1,34 @@
-import "package:flutter/material.dart";
-import "package:yjg/shared/widgets/base_appbar.dart";
-import "package:yjg/shared/widgets/bottom_navigation_bar.dart";
+import 'package:flutter/material.dart';
 import 'package:photo_view/photo_view.dart';
+import 'package:photo_view/photo_view_gallery.dart';
+import 'package:yjg/shared/widgets/base_appbar.dart';
+import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
 
 class AsImageViewDetail extends StatelessWidget {
-  final String imageUrl;
+  final List<String> imageUrls; // 이미지 URL 리스트
 
-  const AsImageViewDetail({Key? key, required this.imageUrl}) : super(key: key);
+  const AsImageViewDetail({Key? key, required this.imageUrls}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: BaseAppBar(title: '사진 상세보기',),
+      appBar: BaseAppBar(title: '사진 상세보기'),
       bottomNavigationBar: const CustomBottomNavigationBar(),
       body: Center(
-        child: PhotoView(
-          imageProvider: NetworkImage(imageUrl),
-      ),
+        child: PhotoViewGallery.builder(
+          scrollPhysics: const BouncingScrollPhysics(),
+          itemCount: imageUrls.length,
+          builder: (context, index) {
+            return PhotoViewGalleryPageOptions(
+              imageProvider: NetworkImage(imageUrls[index]),
+              initialScale: PhotoViewComputedScale.contained,
+            );
+          },
+          backgroundDecoration: BoxDecoration(
+            color: Theme.of(context).canvasColor,
+          ),
+          pageController: PageController(initialPage: 0),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 📣 연관된 이슈
> ex) #이슈번호, #이슈번호

## 📝 작업 내용
- 한국어
> 이미지 상세보기에서 사용자가 스와이프를 하여 다음 이미지로 넘어갈 수 있도록 기능을 추가하였습니다.
- 日本語
> 画像詳細表示でユーザーがスワイプして次の画像に移動できるように機能を追加しました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
