### PR TITLE
Fix: Navigator.pushNamedからpushNamedAndRemoveUntilに変更（ログイン後に戻るを防止）

### DIFF
--- a/lib/as(admin)/presentation/widgets/as_floating_button.dart
+++ b/lib/as(admin)/presentation/widgets/as_floating_button.dart
@@ -29,21 +29,7 @@ class AsFloatingButton extends StatelessWidget {
             onTap: () {
               showAsWritingCommentModal(context);
             }),
-        SpeedDialChild(
-          child: const Icon(
-            Icons.published_with_changes,
-            color: Colors.white,
-          ),
-          label: "상태 변경",
-          backgroundColor: Palette.mainColor,
-          labelBackgroundColor: Palette.mainColor,
-          labelStyle: const TextStyle(
-              fontWeight: FontWeight.w600,
-              color: Colors.white,
-              fontSize: 15.0,
-              letterSpacing: -1),
-          onTap: () {},
-        )
+        
       ],
     );
   }

--- a/lib/auth/data/data_resources/google_login_data_source.dart
+++ b/lib/auth/data/data_resources/google_login_data_source.dart
@@ -91,7 +91,7 @@ class GoogleLoginDataSource {
         if (approved == 1) {
           // 토큰이 null이 아니고, 승인된 계정인 경우
           debugPrint('승인된 계정, 토큰: $token');
-          navigatorKey.currentState!.pushNamed('/dashboard_main'); // 메인으로 이동
+          navigatorKey.currentState!.pushNamedAndRemoveUntil('/dashboard_main', (Route<dynamic> route) => false);
         } else {
           navigatorKey.currentState!
               .pushNamed('/registration_detail'); // 추가 정보 입력 페이지로 이동

--- a/lib/auth/domain/entities/user.dart
+++ b/lib/auth/domain/entities/user.dart
@@ -27,7 +27,7 @@ class User extends ChangeNotifier {
     notifyListeners(); // User 객체가 변경되었음을 알림
   }
 
-  // 회원가입 폼 업데이트
+  // 회원가입, 로그인 폼 업데이트
   void registerFormUpdate({
     String? email,
     String? password,

--- a/lib/auth/domain/usecases/detail_usecase.dart
+++ b/lib/auth/domain/usecases/detail_usecase.dart
@@ -47,8 +47,8 @@ class DetailUseCase {
               content: Text('회원가입에 성공하였습니다.'),
               backgroundColor: Palette.mainColor),
         );
-        // 성공 시 메인 페이지로 이동
-        Navigator.pushNamed(context, '/dashboard_main');
+        // 성공 시 메인 페이지로 이동(이전 페이지로 못 가게 막아버림)
+        Navigator.pushNamedAndRemoveUntil(context, '/dashboard_main', (Route<dynamic> route) => false);
       } else {
         throw Exception('서버 에러: ${response.statusCode}');
       }

--- a/lib/auth/domain/usecases/login_usecase.dart
+++ b/lib/auth/domain/usecases/login_usecase.dart
@@ -22,8 +22,8 @@ class LoginUseCase {
     // 로그인 로직 구현
     try {
       await LoginDataSource().postLoginAPI(ref);
-      // 성공 시 메인 페이지로 이동
-      Navigator.pushNamed(context, '/admin_salon_main');
+      // 성공 시 메인 페이지로 이동(로그인 페이지로 못 가게 막아버림)
+      Navigator.pushNamedAndRemoveUntil(context, '/as_admin', (Route<dynamic> route) => false);
     } catch (e) {
       // 로그인 실패 시 에러 메시지 표시
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/auth/domain/usecases/register_usecase.dart
+++ b/lib/auth/domain/usecases/register_usecase.dart
@@ -37,8 +37,8 @@ class RegisterUseCase {
             content: Text('회원가입에 성공하였습니다.'),
             backgroundColor: Palette.mainColor),
       );
-      // 성공 시 로그인 페이지로 이동
-      Navigator.pushNamed(context, '/login_domestic');
+      // 성공 시 로그인 페이지로 이동(이전 페이지로 못 가게 막아버림)
+      Navigator.pushNamedAndRemoveUntil(context, '/login_domestic', (Route<dynamic> route) => false);
     } catch (e) {
       // 회원가입 실패 시 에러 메시지 표시
       ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## 📣 연관된 이슈
> #94 

## 📝 작업 내용
- 한국어
> 1. 로그인 후 페이지 이동 시 뒤로가기 스와이프를 했을 경우, 로그인 페이지로 이동되는 문제가 있어 `Navigator.pushNamed`를 `Navigator.pushNamedAndRemoveUntill`로 변경하여 뒤로가기를 방지하였습니다.
> 2. AS 관리자의 AS 게시글 보기에 있는 플로팅 버튼에서 불필요한 `SpeedDialChild`를 제거하였습니다. (`댓글 작성 SpeedDialChild`를 누르면 댓글 작성 및 상태를 변경할 수 있는 체크 박스 노출)

- 日本語
> 1. ログイン後のページ移動時にバックスワイプした場合、ログインページに移動してしまう問題があったため、`Navigator.pushNamed`を`Navigator.pushNamedAndRemoveUntil`に変更し、戻る動作を防止しました。
> 2. AS管理者のAS掲示板閲覧時のフローティングボタンから不要な`SpeedDialChild`を削除しました。 (`コメント作成のSpeedDialChild`を押すと、コメント作成とステータス変更ができるチェックボックスが表示されます。)

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
