### PR TITLE
Fix: メールアドレスの重複チェック後に会員登録を進行する際のバグ修正

### DIFF
--- a/lib/auth/presentation/pages/international_registration.dart
+++ b/lib/auth/presentation/pages/international_registration.dart
@@ -77,6 +77,10 @@ class InternationalRegisteration extends ConsumerWidget {
                                     .checkEmail(email);
 
                                 if (!emailCheckResult) {
+                                  ref
+                                      .read(emailCheckSuccessStateProvider
+                                          .notifier)
+                                      .setEmailCheckSuccessStateNotifier(true);
                                   // 사용 가능한 이메일
                                   ScaffoldMessenger.of(context).showSnackBar(
                                     SnackBar(
@@ -112,7 +116,7 @@ class InternationalRegisteration extends ConsumerWidget {
                             horizontal: 8, vertical: 14),
                         child: AuthTextFormField(
                           controller: passwordController,
-                          labelText: "비밀번호",
+                          labelText: "비밀번호(8자 이상)",
                           validatorText: "비밀번호를 입력해 주세요.",
                         ),
                       ),
@@ -144,7 +148,19 @@ class InternationalRegisteration extends ConsumerWidget {
                           // 버튼
                           child: ElevatedButton(
                             onPressed: () async {
-                              if (_formKey.currentState!.validate()) {
+                              bool emailCheckSuccess =
+                                  ref.watch(emailCheckSuccessStateProvider);
+
+                              debugPrint('체크:  $emailCheckSuccess');
+                              if (!emailCheckSuccess) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('이메일 중복 검사를 해주세요.'),
+                                    backgroundColor: Colors.red,
+                                  ),
+                                );
+                              } else if (emailCheckSuccess &&
+                                  _formKey.currentState!.validate()) {
                                 // Form이 유효한 경우에만 회원가입 로직 실행
                                 final registerUseCase = RegisterUseCase(
                                     ref: ref); // RegisterUseCase 인스턴스 생성

--- a/lib/auth/presentation/viewmodels/email_viewmodel.dart
+++ b/lib/auth/presentation/viewmodels/email_viewmodel.dart
@@ -17,3 +17,16 @@ class EmailStateNotifier extends StateNotifier<bool?> {
 final emailStateProvider = StateNotifierProvider<EmailStateNotifier, bool?>((ref) {
   return EmailStateNotifier();
 });
+
+
+class EmailCheckSuccessStateNotifier extends StateNotifier<bool> {
+  EmailCheckSuccessStateNotifier() : super(false); 
+
+  void setEmailCheckSuccessStateNotifier(bool isSuccess) {
+    state = isSuccess;
+  }
+}
+
+final emailCheckSuccessStateProvider = StateNotifierProvider<EmailCheckSuccessStateNotifier, bool>((ref) {
+  return EmailCheckSuccessStateNotifier();
+});


### PR DESCRIPTION
## 📣 연관된 이슈
> #103

## 📝 작업 내용

> 한국어
- 이메일 주소 중복 검사 후에 회원가입 진행할 때의 버그를 수정했습니다.
> 일본어
- メールアドレスの重複チェック後に会員登録を進行する際のバグを修正しました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
