### PR TITLE
Feat: 学校のメールではないGoogleメールのログイン防止

### DIFF
--- a/lib/auth/data/data_resources/login_data_source.dart
+++ b/lib/auth/data/data_resources/login_data_source.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:yjg/auth/data/models/admin_service.dart';
+import 'package:yjg/auth/data/models/token_response.dart';
 import 'package:yjg/auth/presentation/viewmodels/privilege_viewmodel.dart';
 import 'package:yjg/auth/presentation/viewmodels/user_viewmodel.dart';
 import 'package:yjg/shared/constants/api_url.dart';
@@ -35,9 +36,10 @@ class LoginDataSource {
 
     debugPrint("현재 라우트: $url");
     debugPrint("로그인 통신 결과: ${response.body}, ${response.statusCode}");
+    Tokengenerated tokenGenerated = Tokengenerated.fromJson(json.decode(response.body));
 
     if (response.statusCode == 200) {
-      String token = response.body;
+      String? token = tokenGenerated.token;
 
       if (token != null) {
         await storage.write(key: 'auth_token', value: token); // 토큰 저장

--- a/lib/auth/domain/usecases/domain_validation_usecase.dart
+++ b/lib/auth/domain/usecases/domain_validation_usecase.dart
@@ -1,0 +1,5 @@
+class DomainValidationUseCase {
+  bool call(String email) {
+    return email.endsWith('@g.yju.ac.kr');
+  }
+}

--- a/lib/auth/presentation/widgets/auth_text_form_field.dart
+++ b/lib/auth/presentation/widgets/auth_text_form_field.dart
@@ -28,7 +28,7 @@ class AuthTextFormField extends ConsumerWidget {
       width: width * 0.8,
       height: height * 0.08,
       child: TextFormField(
-        obscureText: labelText == "비밀번호" ? true : false,
+        obscureText: labelText == "비밀번호(8자 이상)" ? true : false,
         controller: controller,
         decoration: InputDecoration(
           focusedBorder: OutlineInputBorder(

--- a/lib/auth/presentation/widgets/google_login_button.dart
+++ b/lib/auth/presentation/widgets/google_login_button.dart
@@ -18,7 +18,7 @@ class GoogleLoginButton extends ConsumerWidget {
       child: OutlinedButton(
         onPressed: () async {
           try {
-            await GoogleLoginDataSource().signInWithGoogle(ref);
+            await GoogleLoginDataSource().signInWithGoogle(ref, context);
           } catch (error) {
             debugPrint('Error signing in with Google: $error');
           }


### PR DESCRIPTION
## 📣 연관된 이슈
> ex) #98 

## 📝 작업 내용
> 한국어
- 1. 학교 이메일이 아닌 구글 이메일의 로그인 방지를 구현하였습니다.
- 2. riverpod 토큰 state 변수에 잘못된 데이터가 관리되고 있어 발견하여 수정하였습니다.
- 3. 비밀번호의 라벨 텍스트를 수정하였습니다.

> 日本語
- 1. 学校のメールではないGoogleメールのログインを防止するように実装しました。
- 2. riverpodトークンのstate変数に誤ったデータが管理されていることが発見され、修正しました。
- 3. パスワードのラベルテキストを修正しました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
