### PR TITLE
Feat: 価格表ページのAPI通信ロジック作成

### DIFF
--- a/lib/as(admin)/presentation/pages/as_main.dart
+++ b/lib/as(admin)/presentation/pages/as_main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:yjg/shared/widgets/as_card.dart';
 import 'package:yjg/as(admin)/presentation/widgets/as_tabbar.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
-import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
 import 'package:yjg/shared/widgets/custom_singlechildscrollview.dart';
 
@@ -15,7 +14,6 @@ class AsMain extends StatelessWidget {
       length: 2,
       child: Scaffold(
         appBar: const BaseAppBar(title: 'AS관리'),
-        drawer: const BaseDrawer(),
         bottomNavigationBar: const CustomBottomNavigationBar(),
         body: Column(
           children: [

--- a/lib/salon(admin)/presentation/pages/admin_salon_main.dart
+++ b/lib/salon(admin)/presentation/pages/admin_salon_main.dart
@@ -105,7 +105,7 @@ class AdminSalonMain extends StatelessWidget {
               ],
             ),
 
-            // TODO: 하드 코딩(일단 3건만 볼 수 있도록 하기)
+            // ! 하드 코딩(일단 3건만 볼 수 있도록 하기)
             for (int i = 0; i < 3; i++)
               MainRoundedBoxSmall(
                   iconData: Icons.cut,

--- a/lib/salon/data/data_sources/price_data_source.dart
+++ b/lib/salon/data/data_sources/price_data_source.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:yjg/shared/constants/api_url.dart';
+
+class PriceDataSource {
+  String getApiUrl() {
+    // 상수 파일에서 가져온 apiURL 사용
+    return apiURL;
+  }
+
+  static final storage = FlutterSecureStorage(); // 토큰 담는 곳
+
+  // * 카테고리 목록 불러오기
+  Future<http.Response> getCategoryListAPI() async {
+    final token = await storage.read(key: 'auth_token');
+    String url = '$apiURL/api/salon-category';
+
+    final response = await http.get(
+      Uri.parse(url),
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      return response;
+    } else {
+      throw Exception('카테고리 목록을 불러오지 못했습니다.');
+    }
+  }
+
+  // 카테고리별 서비스 목록 불러오기
+  Future<String> getServiceListAPI(
+      String selectedGender, int selectedCategoryId) async {
+    final token = await storage.read(key: 'auth_token');
+    String baseUrl = '$apiURL/api/salon-service';
+
+    debugPrint('선택한 값: $selectedCategoryId, $selectedGender');
+    Map<String, String> queryParams = {
+      'category_id': selectedCategoryId.toString(),
+      'gender': selectedGender
+    };
+
+    Uri uri = Uri.parse(baseUrl).replace(queryParameters: queryParams);
+    final response = await http.get(
+      uri,
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    debugPrint(
+        "통신 결과: ${jsonDecode(utf8.decode(response.bodyBytes))}, ${response.statusCode}");
+
+    if (response.statusCode == 200) {
+      return utf8.decode(response.bodyBytes);
+    } else {
+      throw Exception('서비스 목록을 불러오지 못했습니다.');
+    }
+  }
+}

--- a/lib/salon/data/models/service.dart
+++ b/lib/salon/data/models/service.dart
@@ -1,0 +1,63 @@
+class Servicegenerated {
+  List<Services>? services;
+
+  Servicegenerated({this.services});
+
+  Servicegenerated.fromJson(Map<String, dynamic> json) {
+    if (json['services'] != null) {
+      services = <Services>[];
+      json['services'].forEach((v) {
+        services!.add(Services.fromJson(v));
+      });
+    }
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (services != null) {
+      data['services'] = services!.map((v) => v.toJson()).toList();
+    }
+    return data;
+  }
+}
+
+class Services {
+  int? id;
+  int? salonCategoryId;
+  String? service;
+  String? price;
+  String? gender;
+  String? createdAt;
+  String? updatedAt;
+
+  Services(
+      {this.id,
+      this.salonCategoryId,
+      this.service,
+      this.price,
+      this.gender,
+      this.createdAt,
+      this.updatedAt});
+
+  Services.fromJson(Map<String, dynamic> json) {
+    id = json['id'];
+    salonCategoryId = json['salon_category_id'];
+    service = json['service'];
+    price = json['price'];
+    gender = json['gender'];
+    createdAt = json['created_at'];
+    updatedAt = json['updated_at'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['id'] = id;
+    data['salon_category_id'] = salonCategoryId;
+    data['service'] = service;
+    data['price'] = price;
+    data['gender'] = gender;
+    data['created_at'] = createdAt;
+    data['updated_at'] = updatedAt;
+    return data;
+  }
+}

--- a/lib/salon/presentaion/pages/salon_price_list.dart
+++ b/lib/salon/presentaion/pages/salon_price_list.dart
@@ -1,79 +1,88 @@
-// SalonPriceList.dart
-import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:yjg/salon/data/models/price.dart';
-import '../widgets/multi_select.dart';
-
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/data/data_sources/price_data_source.dart';
+import 'package:yjg/salon/presentaion/widgets/filter_group_botton.dart';
+import 'package:yjg/salon/presentaion/widgets/filter_service_list.dart';
+import 'package:yjg/shared/theme/palette.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
 import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
-import 'package:flutter/services.dart' show rootBundle;
+import 'package:yjg/shared/widgets/custom_singlechildscrollview.dart';
 
-
-class SalonPriceList extends StatefulWidget {
+class SalonPriceList extends ConsumerWidget {
   const SalonPriceList({super.key});
 
   @override
-  _SalonPriceListState createState() => _SalonPriceListState();
-}
-
-class _SalonPriceListState extends State<SalonPriceList> {
-  List<Price> prices = [];
-  List<String> selectedServiceTypes = [];
-
-  @override
-  void initState() {
-    super.initState();
-    loadPrices();
-  }
-
-  Future<void> loadPrices() async {
-    String jsonData = await rootBundle.loadString('assets/test.json');
-    var list = json.decode(jsonData) as List;
-    setState(() {
-      prices = list.map((data) => Price.fromJson(data)).toList();
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-
-    // 필터링(필터링 안 했을 때는 전체 목록 보여주고, 필터링 했을 경우에는 해당 항목만 보여줌)
-    List<Price> filteredPrices;
-    if (selectedServiceTypes.isEmpty) {
-      filteredPrices = prices;
-    } else {
-      filteredPrices = prices
-          .where((price) => selectedServiceTypes.contains(price.serviceType))
-          .toList();
-    }
-
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
+      appBar: BaseAppBar(
+        title: '가격표',
+      ),
       bottomNavigationBar: const CustomBottomNavigationBar(),
-      appBar: const BaseAppBar(title: '가격표'),
       drawer: const BaseDrawer(),
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: [
-          MultiSelect(
-            onSelectionChanged: (selectedTypes) {
-              setState(() {
-                selectedServiceTypes = selectedTypes;
-              });
-            },
-          ),
-          Expanded(
-            child: ListView.builder(
-              itemCount: filteredPrices.length,
-              itemBuilder: (context, index) {
-                return ListTile(
-                  title: Text(filteredPrices[index].serviceName ?? ''),
-                  subtitle: Text('${filteredPrices[index].price ?? ''}원'),
-                );
-              },
+      body: CustomSingleChildScrollView(
+        child: SizedBox(
+          child: Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  height: 12.0,
+                ),
+                Text(
+                  '필터 설정',
+                  style: TextStyle(fontSize: 16.0, fontWeight: FontWeight.w600),
+                ),
+                SizedBox(
+                  height: 10.0,
+                ),
+                Row(
+                  children: [
+                    Text(
+                      '성별',
+                      style:
+                          TextStyle(color: Palette.textColor.withOpacity(0.7)),
+                    ),
+                    SizedBox(
+                      width: 10.0,
+                    ),
+                    FilterGroupButton(dataType: '성별')
+                  ],
+                ),
+                SizedBox(
+                  height: 13.0,
+                ),
+                Row(
+                  children: [
+                    Text(
+                      '유형',
+                      style:
+                          TextStyle(color: Palette.textColor.withOpacity(0.7)),
+                    ),
+                    SizedBox(
+                      width: 10.0,
+                    ),
+                    FilterGroupButton(dataType: '유형')
+                  ],
+                ),
+                SizedBox(
+                  height: 40.0,
+                ),
+                Text(
+                  '서비스 목록',
+                  style: TextStyle(fontSize: 16.0, fontWeight: FontWeight.w600),
+                ),
+                Text('서비스와 가격은 변경될 수 있습니다.', style: TextStyle(fontSize: 12.0, color: Palette.textColor.withOpacity(0.7))),
+                SizedBox(
+                  height: 10.0,
+                ),
+                FilterServiceList(),
+              ],
+
             ),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/salon/presentaion/viewmodels/service_viewmodel.dart
+++ b/lib/salon/presentaion/viewmodels/service_viewmodel.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/data/data_sources/price_data_source.dart';
+import 'package:yjg/salon/data/models/service.dart';
+import 'package:yjg/salon/presentaion/viewmodels/user_selection_viewmodel.dart';
+
+// .family: 동적인 인자를 받을 수 있음, 같은 타입의 여러 값을 가진 프로바이더 생성
+// 인자: 사용자 선택을 식별하는 데에 사용되는 고유키
+final servicesProvider = FutureProvider.autoDispose
+    .family<List<Services>, String>((ref, userSelectionKey) async {
+  // userSelectionProvider를 통해 사용자 선택 정보 가져오기(user_selection_viewmodel.dart 참고)
+  final userSelection = ref.watch(userSelectionProvider);
+  final selectedGender = userSelection.selectedGender; // 성별
+  final selectedCategoryId = userSelection.selectedCategoryId; // 카테고리 아이디
+  if (selectedGender.isNotEmpty && selectedCategoryId != null) {
+    // API body에 들어갈 두 값이 빈 값이 아닐 경우
+    final dataSource = PriceDataSource(); // PriceDataSource 생성
+    String rawData = await dataSource.getServiceListAPI(
+        selectedGender, selectedCategoryId); // API 호출
+    final serviceData =
+        Servicegenerated.fromJson(jsonDecode(rawData)); // Dart 객체로 변환
+    return serviceData.services ?? []; // 서비스 목록이 null일 경우 빈 리스트를 반환
+  }
+  return []; // 선택 성별, id 유효하지 않음 -> 빈 리스트 반환
+});

--- a/lib/salon/presentaion/viewmodels/user_selection_viewmodel.dart
+++ b/lib/salon/presentaion/viewmodels/user_selection_viewmodel.dart
@@ -4,7 +4,7 @@ class UserSelectionState {
   final int selectedCategoryId;
   final String selectedGender;
 
-  UserSelectionState({this.selectedCategoryId = 0, this.selectedGender = ''});
+  UserSelectionState({this.selectedCategoryId = 1, this.selectedGender = 'male'});
 
   UserSelectionState copyWith({int? selectedCategoryId, String? selectedGender}) {
     return UserSelectionState(

--- a/lib/salon/presentaion/widgets/filter_group_botton.dart
+++ b/lib/salon/presentaion/widgets/filter_group_botton.dart
@@ -25,6 +25,18 @@ class FilterGroupButton extends ConsumerWidget {
         final categoryNames = categoryData.values.toList();
         final buttons = dataType == '성별' ? genderData : categoryNames;
 
+        // 기본 선택 인덱스 계산
+        int defaultSelectedIndex = dataType == '성별'
+            ? genderData.indexOf(userSelection.selectedGender)
+            : categoryData.keys
+                .toList()
+                .indexOf(userSelection.selectedCategoryId);
+
+        // GroupButtonController 초기화
+        final controller = GroupButtonController(
+          selectedIndex: defaultSelectedIndex,
+        );
+
         return GroupButton(
           isRadio: true,
           buttons: buttons,
@@ -45,22 +57,16 @@ class FilterGroupButton extends ConsumerWidget {
               debugPrint(ref.read(userSelectionProvider).toString());
             }
           },
-          controller: GroupButtonController(
-            selectedIndex: dataType == '성별'
-                ? buttons.indexOf(userSelection.selectedGender)
-                : categoryData.keys
-                    .toList()
-                    .indexOf(userSelection.selectedCategoryId),
-          ),
+          controller: controller,
           options: GroupButtonOptions(
-            buttonWidth: 90.0,
-            buttonHeight: 40.0,
+            buttonWidth: 65.0,
+            buttonHeight: 25.0,
             unselectedColor: Colors.grey[300],
             unselectedTextStyle: TextStyle(
               color: Colors.grey[600],
             ),
-            selectedColor: Palette.mainColor.withOpacity(0.8),
-            selectedBorderColor: Palette.mainColor,
+            selectedColor: Palette.mainColor,
+            elevation: 0,
             selectedTextStyle: TextStyle(
               color: Colors.white,
             ),

--- a/lib/salon/presentaion/widgets/filter_service_list.dart
+++ b/lib/salon/presentaion/widgets/filter_service_list.dart
@@ -1,0 +1,67 @@
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:yjg/salon/presentaion/viewmodels/service_viewmodel.dart";
+import "package:yjg/salon/presentaion/viewmodels/user_selection_viewmodel.dart";
+import "package:yjg/shared/theme/palette.dart";
+import 'package:intl/intl.dart';
+
+class FilterServiceList extends ConsumerWidget {
+  const FilterServiceList({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 사용자 선택에 따른 고유 키 생성(.family는 인자로 고유키를 받음)
+    final userSelection = ref.watch(userSelectionProvider);
+    final selectedGender = userSelection.selectedGender; // 성별
+    final selectedCategoryId = userSelection.selectedCategoryId;
+    String uniqueKey = "${selectedGender}_${selectedCategoryId}";
+
+    final servicesAsyncValue = ref.watch(servicesProvider(uniqueKey));
+
+    return servicesAsyncValue.when(
+      data: (services) => ListView.builder(
+        shrinkWrap: true,
+        physics: NeverScrollableScrollPhysics(),
+        itemCount: services.length,
+        itemBuilder: (context, index) {
+          final service = services[index];
+          final formattedPrice = NumberFormat('#,###', 'ko_KR')
+                  .format(int.parse(service.price ?? '0')) +
+              '원'; // 금액 포맷팅
+          return Container(
+            padding: EdgeInsets.symmetric(horizontal: 30.0),
+            margin: EdgeInsets.symmetric(vertical: 10.0),
+            height: 70.0,
+            decoration: BoxDecoration(
+              color: Palette.backgroundColor,
+              borderRadius: BorderRadius.circular(10.0),
+              border: Border.all(color: Colors.grey.shade300, width: 1.0),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  service.service ?? "Unknown Service",
+                  style: TextStyle(fontSize: 16.0),
+                ),
+                Text(
+                  formattedPrice,
+                  style: TextStyle(color: Palette.mainColor),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+      loading: () => Center(
+        child: Padding(
+          padding: const EdgeInsets.only(top: 100.0),
+          child: CircularProgressIndicator(
+            color: Palette.stateColor4,
+          ),
+        ),
+      ),
+      error: (error, stack) => Text('Error: $error'),
+    );
+  }
+}


### PR DESCRIPTION
## 📣 연관된 이슈
> #100 

## 📝 작업 내용
> 한국어
1. 미용실 가격표 페이지의 UI를 개선하였습니다.
2. 미용실 가격표 페이지 관련 API 통신 로직을 작성하였습니다.
- `getCategoryListAPI` : 카테고리 목록을 불러오는 API
- `getServiceListAPI`: 성별과 카테고리 아이디 값을 기반으로 필터링된 서비스 목록을 불러오는 API
3. API 통신으로부터 return 된 값을 가격표 페이지의 UI에 랜더링하기 위해 viewmodel을 작성하였습니다.
- `service_viewmodel.dart` : `FutureProvider.autoDispose.family`를 이용하여 선택 정보를 기반으로 UI에 동적으로 랜더링합니다.
4. API 통신으로 return 된 json 데이터를 Dart 객체로 변환하기 위한 `service` 모델을 작성하였습니다.
5. 관리자 메인 페이지에 등록되어 있던 drawer를 제거하였습니다.

> 일본어

1. 美容室の価格表ページのUIを改善しました。
2. 美容室の価格表ページに関連するAPI通信ロジックを作成しました。
- `getCategoryListAPI`：カテゴリーリストを取得するAPI
- `getServiceListAPI`：性別とカテゴリーIDを基にフィルタリングされたサービスリストを取得するAPI
3. API通信から返された値を価格表ページのUIにレンダリングするために、viewmodelを作成しました。
- `service_viewmodel.dart`：`FutureProvider.autoDispose.family`を使用して、選択情報に基づいてUIに動的にレンダリングします。
4. API通信で返されたJSONデータをDartオブジェクトに変換するためのserviceモデルを作成しました。
5. 管理者メインページに設置されていたドロワーを削除しました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
