### PR TITLE
Refactor: 特定の日付の営業時間を読み込むようにAPIをリファクタリング

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5,6 +5,8 @@ PODS:
   - AppAuth/Core (1.7.1)
   - AppAuth/ExternalUserAgent (1.7.1):
     - AppAuth/Core
+  - device_info_plus (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
   - flutter_native_splash (0.0.1):
     - Flutter
@@ -34,6 +36,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
@@ -51,6 +54,8 @@ SPEC REPOS:
     - GTMSessionFetcher
 
 EXTERNAL SOURCES:
+  device_info_plus:
+    :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
   flutter_native_splash:
@@ -70,6 +75,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppAuth: e93b919be5dbcbba49555011ce94f7d716368574
+  device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be

--- a/lib/auth/domain/entities/user.dart
+++ b/lib/auth/domain/entities/user.dart
@@ -7,6 +7,7 @@ class User extends ChangeNotifier {
   String phoneNumber;
   String displayName;
   String studentId;
+  String idToken;
 
   User(
       {required this.email,
@@ -14,7 +15,8 @@ class User extends ChangeNotifier {
       required this.name,
       required this.phoneNumber,
       required this.displayName,
-      required this.studentId,});
+      required this.studentId,
+      required this.idToken});
 
   // 로그인 폼 업데이트
   void loginFormUpdate({
@@ -61,9 +63,11 @@ class User extends ChangeNotifier {
   void updateWithGoogleSignIn({
     String? email,
     String? displayName,
+    String? idToken,
   }) {
     if (email != null) this.email = email;
     if (displayName != null) this.displayName = displayName;
+    if (idToken != null) this.idToken = idToken;
 
     notifyListeners(); // User 객체가 변경되었음을 알림
   }

--- a/lib/auth/presentation/viewmodels/user_viewmodel.dart
+++ b/lib/auth/presentation/viewmodels/user_viewmodel.dart
@@ -10,6 +10,7 @@ final userProvider = ChangeNotifierProvider<User>((ref) {
     phoneNumber: "phoneNumber",
     displayName: "displayName",
     studentId: "studentId",
+    idToken: "idToken",
   );
 });
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:yjg/salon/presentaion/pages/salon_booking_step_two.dart';
 import 'package:yjg/salon/presentaion/pages/salon_main.dart';
 import 'package:yjg/salon/presentaion/pages/salon_my_book.dart';
 import 'package:yjg/salon/presentaion/pages/salon_price_list.dart';
+import 'package:yjg/shared/service/device_info.dart';
 // import 'package:yjg/shared/service/load_set_student_name.dart';
 import 'package:yjg/shared/theme/theme.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -44,6 +45,8 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final storage = FlutterSecureStorage();
   await dotenv.load(fileName: ".env");
+
+  final deviceInfo = await getDeviceInfo();
 
   // String initialRoute = '/salon_main'; // ! 로그인 안 할 경우 원하는 라우터를 입력해주세요.
 
@@ -161,7 +164,7 @@ class MyApp extends ConsumerWidget {
 
         // AS 관련(관리자)
         '/as_admin': (context) => AsMain(),
-        '/as_detail': (context) => AsDetail(),
+        // '/as_detail': (context) => AsDetail(),
       },
     );
   }

--- a/lib/salon/data/data_sources/booking_data_source.dart
+++ b/lib/salon/data/data_sources/booking_data_source.dart
@@ -13,10 +13,11 @@ class BookingDataSource {
   static final storage = FlutterSecureStorage(); // 토큰 담는 곳
 
   // * 영업시간 목록 불러오기
-  Future<http.Response> getSalonHourAPI() async {
+  Future<http.Response> getSalonHourAPI(String day) async {
     final token = await storage.read(key: 'auth_token');
-    String url = '$apiURL/api/salon/hour';
+    String url = '$apiURL/api/salon/hour/$day';
 
+    debugPrint('영업시간 URL: $url ');
     final response = await http.get(
       Uri.parse(url),
       headers: <String, String>{

--- a/lib/salon/data/data_sources/notice_data_source.dart
+++ b/lib/salon/data/data_sources/notice_data_source.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:yjg/salon/data/models/notice.dart';
+import 'package:yjg/shared/constants/api_url.dart';
+
+class NoticeDataSource {
+  String getApiUrl() {
+    // 상수 파일에서 가져온 apiURL 사용
+    return apiURL;
+  }
+
+  static final storage = FlutterSecureStorage(); // 토큰 담는 곳
+
+  Future<List<Notices>> getNoticeAPI() async {
+    final token = await storage.read(key: 'auth_token');
+    String url = '$apiURL/api/notice/recent';
+
+    Map<String, String> queryParams = {
+      'tag': 'salon',
+    };
+
+    Uri uri = Uri.parse(url).replace(queryParameters: queryParams);
+
+    debugPrint(uri.toString());
+
+    final response = await http.get(
+      uri,
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      // JSON 문자열을 Noticegenerated 객체로 변환
+      final noticeGenerated =
+          Noticegenerated.fromJson(json.decode(response.body));
+
+      // Noticegenerated 객체에서 notices 리스트를 반환
+      return noticeGenerated.notices ?? [];
+    } else {
+      throw Exception('공지사항을 불러오는데 실패했습니다.');
+    }
+  }
+}

--- a/lib/salon/data/models/business_hours.dart
+++ b/lib/salon/data/models/business_hours.dart
@@ -1,37 +1,42 @@
-import 'package:intl/intl.dart';
+class BusinessHoursgenerated {
+  List<BusinessHours>? businessHours;
 
-class BusinessHours {
-  String? sTime;
-  String? eTime;
-  String? date;
+  BusinessHoursgenerated({this.businessHours});
 
-  BusinessHours({this.sTime, this.eTime, this.date});
-
-  BusinessHours.fromJson(Map<String, dynamic> json) {
-    sTime = json['s_time'];
-    eTime = json['e_time'];
-    date = json['date'];
+  BusinessHoursgenerated.fromJson(Map<String, dynamic> json) {
+    if (json['business_hours'] != null) {
+      businessHours = <BusinessHours>[];
+      json['business_hours'].forEach((v) {
+        businessHours!.add(new BusinessHours.fromJson(v));
+      });
+    }
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
-    data['s_time'] = sTime;
-    data['e_time'] = eTime;
-    data['date'] = date;
+    if (businessHours != null) {
+      data['business_hours'] =
+          businessHours!.map((v) => v.toJson()).toList();
+    }
     return data;
   }
+}
 
-  // 30분 단위로 시간 리스트 생성
-  List<String> getTimeSlots() {
-    List<String> slots = [];
-    DateTime start = DateFormat("HH:mm").parse(sTime!);
-    DateTime end = DateFormat("HH:mm").parse(eTime!).add(Duration(minutes: 30));
+class BusinessHours {
+  String? time;
+  bool? available;
 
-    while(start.isBefore(end)) {
-      slots.add(DateFormat("HH:mm").format(start));
-      start = start.add(Duration(minutes: 30));
-    }
+  BusinessHours({this.time, this.available});
 
-    return slots;
+  BusinessHours.fromJson(Map<String, dynamic> json) {
+    time = json['time'];
+    available = json['available'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['time'] = time;
+    data['available'] = available;
+    return data;
   }
 }

--- a/lib/salon/data/models/notice.dart
+++ b/lib/salon/data/models/notice.dart
@@ -1,0 +1,75 @@
+class Noticegenerated {
+  List<Notices>? notices;
+
+  Noticegenerated({this.notices});
+
+  Noticegenerated.fromJson(Map<String, dynamic> json) {
+    if (json['notices'] != null) {
+      notices = <Notices>[];
+      json['notices'].forEach((v) {
+        notices!.add(Notices.fromJson(v));
+      });
+    }
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (notices != null) {
+      data['notices'] = notices!.map((v) => v.toJson()).toList();
+    }
+    return data;
+  }
+}
+
+class Notices {
+  int? id;
+  int? adminId;
+  String? title;
+  String? content;
+  String? tag;
+  int? urgent;
+  String? createdAt;
+  String? updatedAt;
+  List<String>? noticeImages;
+
+  Notices(
+      {this.id,
+      this.adminId,
+      this.title,
+      this.content,
+      this.tag,
+      this.urgent,
+      this.createdAt,
+      this.updatedAt,
+      this.noticeImages});
+
+  Notices.fromJson(Map<String, dynamic> json) {
+    id = json['id'];
+    adminId = json['admin_id'];
+    title = json['title'];
+    content = json['content'];
+    tag = json['tag'];
+    urgent = json['urgent'];
+    createdAt = json['created_at'];
+    updatedAt = json['updated_at'];
+    if (json['notice_images'] != null) {
+      noticeImages = List<String>.from(json['notice_images']);
+    }
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['id'] = id;
+    data['admin_id'] = adminId;
+    data['title'] = title;
+    data['content'] = content;
+    data['tag'] = tag;
+    data['urgent'] = urgent;
+    data['created_at'] = createdAt;
+    data['updated_at'] = updatedAt;
+    if (noticeImages != null) {
+      data['notice_images'] = noticeImages!;
+    }
+    return data;
+  }
+}

--- a/lib/salon/domain/usecases/reservation_usecase.dart
+++ b/lib/salon/domain/usecases/reservation_usecase.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:yjg/salon/data/data_sources/booking_data_source.dart';
+import 'package:yjg/salon/presentaion/viewmodels/booking_select_list_viewmodel.dart';
 import 'package:yjg/shared/theme/palette.dart';
 
 class ReservationUseCase {
@@ -10,14 +12,16 @@ class ReservationUseCase {
 
   // * API 통신
   Future<void> createReservation(int serviceId, String reservationDate,
-      String reservationTime, BuildContext context) async {
+      String reservationTime, BuildContext context, WidgetRef ref) async {
     try {
       final response = await _bookingDataSource.postReservationAPI(
           serviceId, reservationDate, reservationTime);
 
       // 예약 생성 API 호출 결과 처리
       if (response.statusCode == 201) {
-        // 예약 성공 시 처리 로직
+
+        // 예약 시간 초기화
+        ref.read(selectedTimeSlotProvider.notifier).state = null;
 
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/lib/salon/presentaion/pages/salon_main.dart
+++ b/lib/salon/presentaion/pages/salon_main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/presentaion/viewmodels/notice_viewmodel.dart';
 import 'package:yjg/salon/presentaion/viewmodels/reservations_viewmodel.dart';
 import 'package:yjg/shared/theme/palette.dart';
 import 'package:yjg/shared/widgets/base_drawer.dart';
@@ -18,128 +19,161 @@ class SalonMain extends ConsumerStatefulWidget {
 }
 
 class _SalonMainState extends ConsumerState<SalonMain> {
-
-  // 페이지 진입 시에 초기화 작업을 수행
   @override
   void initState() {
     super.initState();
-    Future.microtask(() => ref.refresh(reservationsProvider));
+    Future.microtask(() {
+      ref.refresh(reservationsProvider);
+      ref.refresh(noticeProvider);
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     final reservationsAsyncValue = ref.watch(reservationsProvider);
+    final noticesAsyncValue = ref.watch(noticeProvider);
 
     return Scaffold(
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '미용실'),
       drawer: const BaseDrawer(),
-      body: reservationsAsyncValue.when(
-        data: (reservations) {
-          final bool hasReservations = reservations.isNotEmpty;
-          return SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                SizedBox(
-                  height: 150.0,
-                  child: Stack(
-                    children: [
-                      const BlueMainRoundedBox(),
-                      Positioned(
-                        top: 15,
-                        left: 0,
-                        right: 0,
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 12.0),
-                          child: WhiteMainRoundedBox(
-                            iconData: Icons.cut,
-                            mainText: hasReservations
-                                ? '미용실 예약이 있습니다.'
-                                : '미용실 예약이 없습니다.',
-                            secondaryText: hasReservations
-                                ? '예약 시간을 꼭 지켜주세요.'
-                                : "미용실을 이용해 보세요!",
-                            actionText: '예약 확인하기',
-                            page: 'salon',
+      body: Stack(
+        children: [
+          AnimatedSwitcher( // 두 개의 비동기 상태를 모두 로딩이 완료되면 페이지 내용을 표시
+            duration: const Duration(milliseconds: 300),
+            child: (reservationsAsyncValue.when(
+                      data: (_) => true,
+                      loading: () => false,
+                      error: (_, __) => true,
+                    ) &&
+                    noticesAsyncValue.when(
+                      data: (_) => true,
+                      loading: () => false,
+                      error: (_, __) => true,
+                    ))
+                ? SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        // 예약 정보
+                        reservationsAsyncValue.when(
+                          data: (reservations) {
+                            final bool hasReservations =
+                                reservations.isNotEmpty;
+                            return SizedBox(
+                              height: 150.0,
+                              child: Stack(
+                                children: [
+                                  const BlueMainRoundedBox(),
+                                  Positioned(
+                                    top: 15,
+                                    left: 0,
+                                    right: 0,
+                                    child: Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                          horizontal: 12.0),
+                                      child: WhiteMainRoundedBox(
+                                        iconData: Icons.cut,
+                                        mainText: hasReservations
+                                            ? '미용실 예약이 있습니다.'
+                                            : '미용실 예약이 없습니다.',
+                                        secondaryText: hasReservations
+                                            ? '예약 시간을 꼭 지켜주세요.'
+                                            : '미용실을 이용해 보세요!',
+                                        actionText: '예약 확인하기',
+                                        page: 'salon',
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                          loading: () => Container(), // 로딩 중에는 이미 인디케이터를 표시함
+                          error: (error, _) =>
+                              Center(child: Text('Error: $error')),
+                        ),
+                        // 이용 안내
+                        Container(
+                          margin: const EdgeInsets.all(20),
+                          alignment: Alignment.centerLeft,
+                          child: const Text(
+                            '미용실 이용하기',
+                            style: TextStyle(
+                                fontSize: 16, fontWeight: FontWeight.bold),
                           ),
                         ),
-                      ),
-                    ],
-                  ),
-                ),
-                Container(
-                  margin: const EdgeInsets.all(20),
-                  alignment: const Alignment(-0.85, 0.2),
-                  child: const Text(
-                    '미용실 이용하기',
-                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                  ),
-                ),
-                const Wrap(
-                  spacing: 30,
-                  runSpacing: 30,
-                  children: <Widget>[
-                    MoveButton(
-                        icon: Icons.add_task,
-                        text1: '예약',
-                        text2: '미용실 예약',
-                        route: '/salon_booking_step_one'),
-                    MoveButton(
-                        icon: Icons.content_paste_search,
-                        text1: '가격표',
-                        text2: '미용실 이용 가격 안내',
-                        route: '/salon_price_list'),
-                  ],
-                ),
-                const SizedBox(height: 20),
-                Container(
-                  margin: const EdgeInsets.all(20),
-                  alignment: const Alignment(-0.85, 0.2),
-                  child: const Text(
-                    '미용실 공지사항',
-                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                  ),
-                ),
-                SizedBox(
-                  height: 140.0,
-                  child: ListView(
-                    scrollDirection: Axis.horizontal,
-                    children: const [
-                      Padding(
-                        padding: EdgeInsets.only(right: 20.0),
-                        child: NoticeBox(
-                          title: '미용실 휴무 안내',
-                          content:
-                              '미용실 휴무합니다. 2025년 1월 1일부터 2025년 1월 3일까지 휴무이므로, 이용....',
+                        const Wrap(
+                          spacing: 30,
+                          runSpacing: 30,
+                          children: <Widget>[
+                            MoveButton(
+                                icon: Icons.add_task,
+                                text1: '예약',
+                                text2: '미용실 예약',
+                                route: '/salon_booking_step_one'),
+                            MoveButton(
+                                icon: Icons.content_paste_search,
+                                text1: '가격표',
+                                text2: '미용실 이용 가격 안내',
+                                route: '/salon_price_list'),
+                          ],
                         ),
-                      ),
-                      Padding(
-                        padding: EdgeInsets.only(right: 20.0),
-                        child: NoticeBox(
-                          title: '미용실 휴무 안내',
-                          content:
-                              '미용실 휴무합니다. 2025년 1월 1일부터 2025년 1월 3일까지 휴무이므로, 이용....',
+                        // 공지사항
+                        Container(
+                          margin: const EdgeInsets.symmetric(
+                              vertical: 20, horizontal: 20),
+                          alignment: Alignment.centerLeft,
+                          child: const Text(
+                            '미용실 공지사항',
+                            style: TextStyle(
+                                fontSize: 16, fontWeight: FontWeight.bold),
+                          ),
                         ),
-                      ),
-                      Padding(
-                        padding: EdgeInsets.only(right: 20.0),
-                        child: NoticeBox(
-                          title: '미용실 휴무 안내',
-                          content:
-                              '미용실 휴무합니다. 2025년 1월 1일부터 2025년 1월 3일까지 휴무이므로, 이용....',
+                        noticesAsyncValue.when(
+                          data: (notices) {
+                            return SizedBox(
+                              height: 140.0,
+                              child: ListView.builder(
+                                scrollDirection: Axis.horizontal,
+                                itemCount: notices.length,
+                                itemBuilder: (context, index) {
+                                  final notice = notices[index];
+                                  return Padding(
+                                    padding: const EdgeInsets.only(right: 20.0),
+                                    child: NoticeBox(
+                                      title: notice.title ?? '제목 없음',
+                                      content: notice.content ?? '내용 없음',
+                                    ),
+                                  );
+                                },
+                              ),
+                            );
+                          },
+                          loading: () => Container(), // 로딩 중에는 이미 인디케이터를 표시함
+                          error: (error, _) =>
+                              Center(child: Text('Error: $error')),
                         ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
+                      ],
+                    ),
+                  )
+                : Container(), // 로딩 중에는 페이지 내용을 숨김
+          ),
+          // 로딩 인디케이터
+          if (reservationsAsyncValue.when(
+                data: (_) => false,
+                loading: () => true,
+                error: (_, __) => false,
+              ) ||
+              noticesAsyncValue.when(
+                data: (_) => false,
+                loading: () => true,
+                error: (_, __) => false,
+              ))
+            const Center(
+              child: CircularProgressIndicator(color: Palette.stateColor4),
             ),
-          );
-        },
-        loading: () => const Center(
-            child: CircularProgressIndicator(color: Palette.stateColor4)),
-        error: (error, _) => Center(child: Text('Error: $error')),
+        ],
       ),
     );
   }

--- a/lib/salon/presentaion/viewmodels/booking_business_hours_viewmodel.dart
+++ b/lib/salon/presentaion/viewmodels/booking_business_hours_viewmodel.dart
@@ -1,10 +1,14 @@
 import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/salon/data/data_sources/booking_data_source.dart';
 import 'package:yjg/salon/data/models/business_hours.dart';
 
-final salonHoursProvider = FutureProvider<List<BusinessHours>>((ref) async {
-  final response = await BookingDataSource().getSalonHourAPI();
+import 'package:intl/intl.dart'; 
+
+final salonHoursProvider = FutureProvider.family<List<BusinessHours>, String>((ref, date) async {
+  final formattedDate = DateFormat('yyyy-MM-dd').format(DateTime.parse(date)); // 날짜 포맷팅
+  final response = await BookingDataSource().getSalonHourAPI(formattedDate);
   final List<dynamic> decoded = json.decode(response.body)['business_hours'];
   return decoded.map<BusinessHours>((json) => BusinessHours.fromJson(json)).toList();
 });

--- a/lib/salon/presentaion/viewmodels/booking_select_list_viewmodel.dart
+++ b/lib/salon/presentaion/viewmodels/booking_select_list_viewmodel.dart
@@ -1,13 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:yjg/salon/data/models/business_hours.dart';
 
 final selectedDateProvider = StateProvider<DateTime>((ref) => DateTime.now());
-final timeSlotsProvider = StateProvider<List<String>>((ref) {
-  final selectedDate = ref.watch(selectedDateProvider.state).state;
-  
-  return BusinessHours(sTime: "09:00", eTime: "18:00").getTimeSlots();
-});
-
 final selectedTimeSlotProvider = StateProvider<String?>((ref) => null);
 final selectedServiceIdProvider = StateProvider<int>((ref) => -1);
 final selettedServiceNameProvider = StateProvider<String>((ref) => '');

--- a/lib/salon/presentaion/viewmodels/notice_viewmodel.dart
+++ b/lib/salon/presentaion/viewmodels/notice_viewmodel.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/data/data_sources/notice_data_source.dart';
+import 'package:yjg/salon/data/models/notice.dart';
+
+final noticeProvider = FutureProvider.autoDispose<List<Notices>>((ref) async {
+  final dataSource = NoticeDataSource();
+  return await dataSource.getNoticeAPI();
+});

--- a/lib/salon/presentaion/widgets/booking_execution_modal.dart
+++ b/lib/salon/presentaion/widgets/booking_execution_modal.dart
@@ -76,7 +76,7 @@ void bookingExecutionModal(BuildContext context, WidgetRef ref) {
                           await reservationUseCase.createReservation(
                               selectedServiceId,
                               formattedDate!,
-                              selectedTimeSlot!, context);
+                              selectedTimeSlot!, context, ref);
                    
                           ref.refresh(reservationsProvider);
                         } catch (error) {

--- a/lib/salon/presentaion/widgets/time_slots_grid.dart
+++ b/lib/salon/presentaion/widgets/time_slots_grid.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/presentaion/viewmodels/booking_business_hours_viewmodel.dart';
 import 'package:yjg/salon/presentaion/viewmodels/booking_select_list_viewmodel.dart';
 import 'package:yjg/salon/presentaion/widgets/booking_execution_modal.dart';
 import 'package:yjg/shared/theme/theme.dart';
@@ -7,55 +8,58 @@ import 'package:yjg/shared/theme/theme.dart';
 class TimeSlotsGrid extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final timeSlots = ref.watch(timeSlotsProvider);
-    final selectedTimeSlot = ref.watch(selectedTimeSlotProvider.state); 
-    final selectedDate = ref.watch(selectedDateProvider.state).state;
-    return GridView.builder(
-      physics: NeverScrollableScrollPhysics(),
-      shrinkWrap: true,
-      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 4, // 한 줄에 4개의 그리드 아이템
-        childAspectRatio: 2, // 그리드 아이템의 가로세로 비율
-      ),
-      itemCount: timeSlots.length,
-      itemBuilder: (context, index) {
-        bool isSelected = timeSlots[index] == selectedTimeSlot.state; // 현재 타임슬롯이 선택된 상태인지 확인
-        return Padding(
-          padding: const EdgeInsets.all(3.0),
-          child: ElevatedButton(
-            style: ButtonStyle(
-              overlayColor: MaterialStateProperty.all(Colors.transparent),
-              backgroundColor: MaterialStateProperty.resolveWith<Color>(
-                (Set<MaterialState> states) {
-                  if (isSelected) return Color.fromARGB(255, 86, 90, 200); // 선택된 경우의 색
-                  return Palette.backgroundColor; // 기본 배경색
-                },
-              ),
-              foregroundColor: MaterialStateProperty.resolveWith<Color>(
-                (Set<MaterialState> states) {
-                  if (isSelected) return Colors.white; // 선택된 경우의 글자색
-                  return Palette.textColor.withOpacity(0.7); // 기본 글자색
-                },
-              ),
-              shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(5.0),
-                  side: BorderSide(color: Palette.stateColor4.withOpacity(0.4)),
+    final asyncTimeSlots = ref
+        .watch(salonHoursProvider(ref.watch(selectedDateProvider).toString()));
+
+    return asyncTimeSlots.when(
+      data: (timeSlots) => GridView.builder(
+        physics: NeverScrollableScrollPhysics(),
+        shrinkWrap: true,
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 4,
+          childAspectRatio: 2,
+        ),
+        itemCount: timeSlots.length,
+        itemBuilder: (context, index) {
+          bool isSelected = timeSlots[index].time ==
+              ref.watch(selectedTimeSlotProvider.notifier).state;
+          return Padding(
+            padding: const EdgeInsets.all(3.0),
+            child: ElevatedButton(
+              style: ButtonStyle(
+                foregroundColor: MaterialStateProperty.resolveWith<Color>(
+                  (Set<MaterialState> states) {
+                    return Palette.textColor.withOpacity(0.7);
+                  },
+                ),
+                shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(5.0),
+                    side:
+                        BorderSide(color: Palette.stateColor4.withOpacity(0.4)),
+                  ),
                 ),
               ),
+              onPressed: timeSlots[index].available == true
+                  ? () {
+                      // `timeSlots[index].available`이 true일 때 실행할 로직
+                      ref.read(selectedTimeSlotProvider.notifier).state =
+                          timeSlots[index].time;
+
+                      bookingExecutionModal(context, ref);
+                    }
+                  : null, // `timeSlots[index].available`이 false 또는 null일 때는 버튼 비활성화
+
+              child: Text(
+                timeSlots[index].time!,
+                style: TextStyle(fontSize: 12.0, letterSpacing: -0.5),
+              ),
             ),
-            onPressed: () {
-              ref.read(selectedTimeSlotProvider.state).state = timeSlots[index];
-              
-              selectedDate == null ? null : bookingExecutionModal(context, ref); // 선택된 날짜가 없으면 예약 실행 모달, 있으면 다음 모달 호출
-            },
-            child: Text(
-              timeSlots[index],
-              style: TextStyle(fontSize: 12.0, letterSpacing: -0.5),
-            ),
-          ),
-        );
-      },
+          );
+        },
+      ),
+      loading: () => CircularProgressIndicator(),
+      error: (error, stack) => Text('Error: $error'),
     );
   }
 }

--- a/lib/shared/service/device_info.dart
+++ b/lib/shared/service/device_info.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+Future<void> getDeviceInfo() async {
+  DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
+  String deviceData;
+  final storage = FlutterSecureStorage();
+
+  if (Platform.isAndroid) {
+    AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;
+    deviceData = 'Android ${androidInfo.version.sdkInt}, ${androidInfo.model}';
+    storage.write(key: 'deviceType', value: 'Android');
+  } else if (Platform.isIOS) {
+    IosDeviceInfo iosInfo = await deviceInfo.iosInfo;
+    deviceData = 'iOS ${iosInfo.systemVersion}, ${iosInfo.utsname.machine}';
+    storage.write(key: 'deviceType', value: 'iOS');
+  } else {
+    deviceData = 'Unknown device';
+  }
+
+  debugPrint('Device Info: ${await storage.read(key: 'deviceType')}');
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import device_info_plus
 import file_selector_macos
 import flutter_secure_storage_macos
 import google_sign_in_ios
@@ -12,6 +13,7 @@ import path_provider_foundation
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      sha256: "77f757b789ff68e4eaf9c56d1752309bd9f7ad557cb105b938a7f8eb89e59110"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.2"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   dotted_line:
     dependency: "direct main"
     description:
@@ -866,6 +882,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "41fd8a189940d8696b1b810efb9abcf60827b6cbfab90b0c43e8439e3a39d85a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   shared_preferences: ^2.2.2
   flutter_html: ^3.0.0-beta.2
   collection: ^1.18.0
+  device_info_plus: ^9.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📣 연관된 이슈
> #118 #112

## 📝 작업 내용
> 한국어
1. 앱 실행 시 디바이스 정보를 읽어오고, 구글 로그인 후 토큰 교환 시에 디바이스 정보를 보내도록 수정하였습니다. (엔티티, viewmodel 수정)
2. 미용실 메인페이지에서 최근에 작성된 공지사항 3건이 보이도록 UI 수정 및, API 통신 로직을 작성하였습니다. (model, viewmodel 작성)
3. 미용실 예약 시 달력에서 날짜를 누르면 그 날짜의 영업 시간이 나오도록 API 교체 후 관련 로직 및 위젯들을 수정하였습니다. 

> 日本語
1. アプリ実行時にデバイス情報を読み込み、Googleログイン後のトークン交換時にデバイス情報を送信するように変更しました。（エンティティ、ビューモデルを修正）
2. 美容室のメインページで、最近投稿されたお知らせ3件が表示されるようにUIを修正し、API通信ロジックを作成しました。（モデル、ビューモデルを作成）
3. 美容室の予約時にカレンダーから日付を選ぶと、その日の営業時間が表示されるようにAPIを交換後、関連ロジックおよびウィジェットを修正しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
