### PR TITLE
Feat: アクセストークンの期限切れに伴うリフレッシュトークンの送信ロジックの実装

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -66,7 +66,6 @@
 		B964D164292AAFD5C3F60AB2 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		BF8F3F106DCF9122B47F07C5 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8EEEB968BF4C658107730D0 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		FA7F9FA12B84FB8E005E8FE6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		FA829E392B84C27000C3D7D1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -112,7 +111,6 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
-				FA7F9FA12B84FB8E005E8FE6 /* GoogleService-Info.plist */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:GoogleService-Info.plist">
+   </FileRef>
+   <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
    <FileRef

--- a/lib/auth/data/data_resources/register_data_source.dart
+++ b/lib/auth/data/data_resources/register_data_source.dart
@@ -20,8 +20,6 @@ class RegisterDataSource {
       'student_id': registerState.studentId,
     });
 
-    debugPrint('내가 보낸 body: $body');
-
     // 통신
     final response = await http.post(
       Uri.parse('$apiURL/api/user'),
@@ -61,7 +59,7 @@ class RegisterDataSource {
         // state 값을 json 형태로 변환
         body: body);
 
-    debugPrint(body);
+    debugPrint('추가 정보 입력 결과: ${response.body}, ${response.statusCode}');
 
     // status code가 200이 아닐 경우
     if (response.statusCode != 200) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,8 @@ import 'package:yjg/salon/presentaion/pages/salon_main.dart';
 import 'package:yjg/salon/presentaion/pages/salon_my_book.dart';
 import 'package:yjg/salon/presentaion/pages/salon_price_list.dart';
 import 'package:yjg/shared/service/device_info.dart';
-// import 'package:yjg/shared/service/load_set_student_name.dart';
+import 'package:yjg/shared/service/load_set_student_name.dart';
+import 'package:yjg/shared/service/token_decoder.dart';
 import 'package:yjg/shared/theme/theme.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -55,6 +56,7 @@ void main() async {
   final autoLoginStr = await storage.read(key: 'auto_login');
   final isAutoLogin = autoLoginStr == 'true';
   final token = await storage.read(key: 'auth_token');
+  tokenDecoder(token);
   String? userType = await storage.read(key: 'userType');
 
   if (isAutoLogin && token != null) {
@@ -97,7 +99,7 @@ class MyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // loadAndSetStudentName(ref); // 로그인 이름 설정
+    loadAndSetStudentName(ref); // 로그인 이름 설정
 
     return MaterialApp(
       //외박 신청 달력 언어 설정

--- a/lib/salon/data/data_sources/booking_data_source.dart
+++ b/lib/salon/data/data_sources/booking_data_source.dart
@@ -17,7 +17,6 @@ class BookingDataSource {
     final token = await storage.read(key: 'auth_token');
     String url = '$apiURL/api/salon/hour/$day';
 
-    debugPrint('영업시간 URL: $url ');
     final response = await http.get(
       Uri.parse(url),
       headers: <String, String>{
@@ -27,7 +26,6 @@ class BookingDataSource {
     );
 
     if (response.statusCode == 200) {
-      debugPrint('영업시간 목록: ${response.body}');
       return response;
     } else {
       throw Exception('영업시간 목록을 불러오지 못했습니다.');
@@ -60,8 +58,6 @@ class BookingDataSource {
     final token = await storage.read(key: 'auth_token');
     String url = '$apiURL/api/salon/reservation/$reservationId';
 
-    debugPrint('예약 취소 URL: $url');
-    debugPrint(url);
     final response = await http.delete(
       Uri.parse(url),
       headers: <String, String>{
@@ -69,8 +65,6 @@ class BookingDataSource {
         'Authorization': 'Bearer $token',
       },
     );
-
-    debugPrint('예약 취소 결과: ${response.body} ${response.statusCode}');
 
     if (response.statusCode == 200) {
       return true;

--- a/lib/salon/data/data_sources/notice_data_source.dart
+++ b/lib/salon/data/data_sources/notice_data_source.dart
@@ -24,8 +24,6 @@ class NoticeDataSource {
 
     Uri uri = Uri.parse(url).replace(queryParameters: queryParams);
 
-    debugPrint(uri.toString());
-
     final response = await http.get(
       uri,
       headers: <String, String>{

--- a/lib/shared/service/auth_service.dart
+++ b/lib/shared/service/auth_service.dart
@@ -6,6 +6,8 @@ class AuthService {
 
   Future<void> logout(BuildContext context) async {
     await storage.delete(key: 'auth_token');
+    await storage.delete(key: 'refresh_token');
+    await storage.delete(key: 'studentName');
     debugPrint('로그아웃 완료');
     Navigator.pushNamedAndRemoveUntil(context, '/login_student', (route) => false);
   }

--- a/lib/shared/service/token_decoder.dart
+++ b/lib/shared/service/token_decoder.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:jwt_decoder/jwt_decoder.dart';
+import 'package:yjg/auth/data/data_resources/login_data_source.dart';
+
+void tokenDecoder(String? token) {
+  bool hasExpired = JwtDecoder.isExpired(token!);
+
+  debugPrint('토큰 만료 여부: $hasExpired');
+  if (hasExpired) {
+    LoginDataSource().getRefreshTokenAPI();
+    debugPrint('토큰 교체 완료');
+  } else {
+    final payload = JwtDecoder.decode(token);
+    debugPrint('토큰 payload: $payload');
+  }
+}
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -501,6 +501,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  jwt_decoder:
+    dependency: "direct main"
+    description:
+      name: jwt_decoder
+      sha256: "54774aebf83f2923b99e6416b4ea915d47af3bde56884eb622de85feabbc559f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   flutter_html: ^3.0.0-beta.2
   collection: ^1.18.0
   device_info_plus: ^9.1.2
+  jwt_decoder: ^2.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📣 연관된 이슈
> #121

## 📝 작업 내용
> 한국어
- 액세스 토큰의 만료 여부를 파악하여, 만료됐을 시 `api/refresh`로 통신하는 로직을 구현하였습니다.

> 日本語
- アクセストークンの有効期限の有無を確認し、期限が切れた場合にapi/refreshで通信するロジックを実装しました。

## 💬 리뷰 요구사항 (선택)
> 버스 API 연결 작업이 끝나면 테스트 예정입니다.
