### PR TITLE
Feat: 美容室の価格表サービスを追加するAPI通信ロジックの実装

### DIFF
--- a/lib/auth/data/data_resources/login_data_source.dart
+++ b/lib/auth/data/data_resources/login_data_source.dart
@@ -119,7 +119,7 @@ class LoginDataSource {
 
     if (response.statusCode == 200) {
       final responseData = json.decode(response.body);
-      final accessToken = responseData['response_token'];
+      final accessToken = responseData['refresh_token'];
       debugPrint('리프레시 토큰 교환 완료, 액세스 토큰 교체: $accessToken');
 
       // 토큰 교체

--- a/lib/salon/presentaion/pages/admin/admin_salon_price_list.dart
+++ b/lib/salon/presentaion/pages/admin/admin_salon_price_list.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/presentaion/viewmodels/user_selection_viewmodel.dart';
+import 'package:yjg/salon/presentaion/widgets/admin/add_service_modal.dart';
 import 'package:yjg/salon/presentaion/widgets/admin/edit_service_button.dart';
-import 'package:yjg/salon/presentaion/widgets/booking_service_button.dart';
 import 'package:yjg/salon/presentaion/widgets/filter_group_botton.dart';
 import 'package:yjg/shared/theme/palette.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
@@ -8,11 +10,15 @@ import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
 import 'package:yjg/shared/widgets/custom_singlechildscrollview.dart';
 
-class AdminSalonPricelist extends StatelessWidget {
+class AdminSalonPricelist extends ConsumerWidget {
   AdminSalonPricelist({Key? key}) : super(key: key);
-
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userSelection = ref.watch(userSelectionProvider);
+    final selectedGender = userSelection.selectedGender;
+    final selectedCategoryId = userSelection.selectedCategoryId;
+    String uniqueKey = "${selectedGender}_${selectedCategoryId}";
+
     return Scaffold(
       appBar: BaseAppBar(title: "미용실 예약"),
       bottomNavigationBar: const CustomBottomNavigationBar(),
@@ -33,14 +39,18 @@ class AdminSalonPricelist extends StatelessWidget {
                     style:
                         TextStyle(fontSize: 16.0, fontWeight: FontWeight.bold),
                   ),
+                  SizedBox(
+                    width: 10.0,
+                  ),
                   InkWell(
                     onTap: () {
-                      // 카테고리 추가 모달 호출
+                      addServiceModal(context, ref, uniqueKey);
                     },
-                    child: Icon(
-                      Icons.add,
-                      size: 20.0,
-                    ),
+                    child: Text('추가',
+                        style: TextStyle(
+                            color: Palette.mainColor,
+                            fontSize: 14.0,
+                            fontWeight: FontWeight.bold)),
                   ),
                 ],
               ),
@@ -84,21 +94,25 @@ class AdminSalonPricelist extends StatelessWidget {
                     style:
                         TextStyle(fontSize: 16.0, fontWeight: FontWeight.bold),
                   ),
+                  SizedBox(
+                    width: 10.0,
+                  ),
                   InkWell(
                     onTap: () {
-                      // 카테고리 추가 모달 호출
+                      addServiceModal(context, ref, uniqueKey);
                     },
-                    child: Icon(
-                      Icons.add,
-                      size: 20.0,
-                    ),
+                    child: Text('추가',
+                        style: TextStyle(
+                            color: Palette.mainColor,
+                            fontSize: 14.0,
+                            fontWeight: FontWeight.bold)),
                   ),
                 ],
               ),
               SizedBox(
                 height: 15.0,
               ),
-              EditServiceButton()
+              EditServiceButton(uniqueKey: uniqueKey)
             ],
           ),
         ),

--- a/lib/salon/presentaion/viewmodels/unique_key_viewmodel.dart
+++ b/lib/salon/presentaion/viewmodels/unique_key_viewmodel.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final uniqueKeyProvider = StateProvider<String>((ref) {
+  return ""; // 초기값 설정
+});

--- a/lib/salon/presentaion/widgets/admin/add_service_modal.dart
+++ b/lib/salon/presentaion/widgets/admin/add_service_modal.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/data/data_sources/admin/admin_service_data_source.dart';
+import 'package:yjg/salon/domain/entities/service.dart';
+import 'package:yjg/salon/domain/usecases/admin_service_usecase.dart';
+import 'package:yjg/salon/presentaion/viewmodels/service_viewmodel.dart';
+import 'package:yjg/salon/presentaion/widgets/admin/category_dropdown.dart';
+import 'package:yjg/shared/theme/palette.dart';
+import 'package:yjg/shared/widgets/custom_singlechildscrollview.dart';
+
+void addServiceModal(BuildContext context, WidgetRef ref, String uniqueKey) {
+  final serviceUseCases = ServiceUseCases(AdminServiceDataSource());
+
+  TextEditingController nameController = TextEditingController();
+  TextEditingController priceController = TextEditingController();
+  String selectedGender = 'male'; // 초기 성별 값
+  String selectedCategory = '1'; // 초기 카테고리 값
+
+  showModalBottomSheet(
+    context: context,
+    builder: (BuildContext context) {
+      return StatefulBuilder(
+        // StatefulBuilder를 사용하여 상태를 관리
+        builder: (context, setState) {
+          return Container(
+            height: MediaQuery.of(context).size.height * 0.9,
+            padding: EdgeInsets.only(left: 20, right: 20, top: 30),
+            child: CustomSingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.max,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    '서비스 등록',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  Text(
+                    '모든 항목을 입력해주세요.',
+                    style: TextStyle(
+                        color: Palette.textColor.withOpacity(0.7),
+                        fontSize: 14),
+                  ),
+                  SizedBox(height: 20),
+                  Text('카테고리',
+                      style: TextStyle(
+                          fontSize: 16,
+                          color: Palette.textColor.withOpacity(0.7))),
+                  SizedBox(width: 10),
+                  CategoryDropdown(
+                    selectedCategory: selectedCategory,
+                    onCategoryChanged: (newValue) {
+                      setState(() {
+                        selectedCategory = newValue;
+                        debugPrint('카테고리: $selectedCategory');
+                      });
+                    },
+                  ),
+                  TextField(
+                    controller: nameController,
+                    decoration: InputDecoration(
+                      labelText: '서비스명',
+                      focusedBorder: UnderlineInputBorder(
+                        borderSide: BorderSide(color: Palette.mainColor),
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: 20),
+                  TextField(
+                    controller: priceController,
+                    decoration: InputDecoration(
+                      labelText: '가격',
+                      focusedBorder: UnderlineInputBorder(
+                        borderSide: BorderSide(color: Palette.mainColor),
+                      ),
+                    ),
+                    keyboardType: TextInputType.number,
+                  ),
+                  SizedBox(height: 20),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Expanded(
+                        child: ListTile(
+                          title: const Text('Male'),
+                          horizontalTitleGap: 0,
+                          leading: Radio<String>(
+                            value: 'male',
+                            groupValue: selectedGender,
+                            onChanged: (value) {
+                              setState(() {
+                                selectedGender = value!;
+                              });
+                            },
+                            activeColor: Palette.mainColor,
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: ListTile(
+                          title: const Text('Female'),
+                          horizontalTitleGap: 0,
+                          leading: Radio<String>(
+                            value: 'female',
+                            groupValue: selectedGender,
+                            onChanged: (value) {
+                              setState(() {
+                                selectedGender = value!;
+                                debugPrint('성별: $selectedGender ');
+                              });
+                            },
+                            activeColor: Palette.mainColor,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: 10),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end, // 완료 버튼을 오른쪽으로 정렬
+                    children: [
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: () async {
+                            // 사용자 입력값을 바탕으로 Service 엔티티 생성
+                            Service newService = Service(
+                              categoryId: int.parse(selectedCategory),
+                              serviceName: nameController.text,
+                              gender: selectedGender,
+                              price: priceController.text,
+                            );
+
+                            // createService 메소드를 호출하여 서비스 추가
+                            ServiceResult result =
+                                await serviceUseCases.createService(newService);
+
+                            if (result.isSuccess) {
+                              // 성공 시 서비스 리스트 상태 업데이트
+                              ref.refresh(servicesProvider(uniqueKey));
+
+                              // 성공 알림 표시
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text(result.message),
+                                  backgroundColor: Palette.mainColor,
+                                ),
+                              );
+
+                              // 모달 창 닫기
+                              Navigator.pop(context);
+                            } else {
+                              // 실패 시 실패 알림 표시
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text(result.message),
+                                  backgroundColor: Colors.red,
+                                ),
+                              );
+                            }
+                          },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Palette.mainColor,
+                            elevation: 0,
+                          ),
+                          child: Text(
+                            '서비스 등록',
+                            style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: 40)
+                ],
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
+}

--- a/lib/salon/presentaion/widgets/admin/category_dropdown.dart
+++ b/lib/salon/presentaion/widgets/admin/category_dropdown.dart
@@ -1,0 +1,44 @@
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:yjg/salon/presentaion/viewmodels/category_viewmodel.dart";
+import "package:yjg/shared/theme/palette.dart";
+
+class CategoryDropdown extends ConsumerWidget {
+  final String selectedCategory;
+  final Function(String) onCategoryChanged;
+
+  const CategoryDropdown({
+    Key? key,
+    required this.selectedCategory,
+    required this.onCategoryChanged,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categoryDataAsyncValue = ref.watch(categoryListProvider);
+    return categoryDataAsyncValue.when(
+      data: (categories) {
+        final categoryItems = categories.entries.map((entry) {
+          return DropdownMenuItem<String>(
+            value: entry.key.toString(),
+            child: Text(entry.value),
+          );
+        }).toList();
+
+        return DropdownButton<String>(
+          value: selectedCategory,
+          onChanged: (value) => onCategoryChanged(value!),
+          items: categoryItems,
+          alignment: Alignment.centerLeft,
+          style: TextStyle(color: Palette.textColor),
+          underline: Container(
+            height: 1.5,
+            color: Palette.textColor.withOpacity(0.4),
+          ),
+        );
+      },
+      loading: () => CircularProgressIndicator(),
+      error: (error, stack) => Text('Error: $error'),
+    );
+  }
+}

--- a/lib/salon/presentaion/widgets/admin/edit_service_button.dart
+++ b/lib/salon/presentaion/widgets/admin/edit_service_button.dart
@@ -3,14 +3,14 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 import 'package:yjg/salon/presentaion/viewmodels/booking_select_id_viewmodel.dart';
 import "package:yjg/salon/presentaion/viewmodels/booking_select_list_viewmodel.dart";
 import "package:yjg/salon/presentaion/viewmodels/service_viewmodel.dart";
-import "package:yjg/salon/presentaion/viewmodels/user_selection_viewmodel.dart";
 import "package:yjg/salon/presentaion/widgets/admin/edit_service_modal.dart";
 import "package:yjg/salon/presentaion/widgets/booking_next_modal.dart";
 import "package:yjg/shared/theme/palette.dart";
 import 'package:intl/intl.dart';
 
 class EditServiceButton extends ConsumerStatefulWidget {
-  const EditServiceButton({super.key});
+  EditServiceButton({super.key, required this.uniqueKey});
+  final String uniqueKey;
 
   @override
   _EditServiceButton createState() => _EditServiceButton();
@@ -37,13 +37,10 @@ class _EditServiceButton extends ConsumerState<EditServiceButton> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    final userSelection = ref.watch(userSelectionProvider);
-    final selectedGender = userSelection.selectedGender;
-    final selectedCategoryId = userSelection.selectedCategoryId;
-    String uniqueKey = "${selectedGender}_${selectedCategoryId}";
-
-    final servicesAsyncValue = ref.watch(servicesProvider(uniqueKey));
+  Widget build(
+    BuildContext context,
+  ) {
+    final servicesAsyncValue = ref.watch(servicesProvider(widget.uniqueKey));
 
     return servicesAsyncValue.when(
       data: (services) => ListView.builder(
@@ -67,8 +64,8 @@ class _EditServiceButton extends ConsumerState<EditServiceButton> {
                   serviceName,
                   service.gender!,
                   ref,
-                  uniqueKey),
-              debugPrint('${ref.read(salonCategoryProvider)}')
+                  widget.uniqueKey),
+              debugPrint('${ref.read(salonCategoryProvider)}'),
             },
             child: Container(
               padding: EdgeInsets.symmetric(horizontal: 30.0, vertical: 20.0),


### PR DESCRIPTION
## 📣 연관된 이슈
> #139 

## 📝 작업 내용
> 한국어
1. 미용실 관리자 가격표 페이지의 서비스 등록 API 통신 로직을 작성하였습니다. (이와 관련된 커스텀 위젯들 작성)
2. 서비스 Provider에 활용하던 UniqueKey 변수의 유연한 활용을 위해 변수 선언 위치를 상위 위젯으로 이동했습니다.
3. 리프레시 토큰 교환 API 통신 로직 내 오탈자를 발견하여 수정하였습니다.

> 日本語
1. 美容室管理者の価格表ページにおけるサービス登録のAPI通信ロジックを作成しました。（関連するカスタムウィジェットも作成）
2. サービスProviderに活用していたUniqueKey変数の柔軟な活用のため、変数宣言位置を親ウィジェットに移動しました。
3. リフレッシュトークン交換のAPI通信ロジック内、誤字を発見して修正しました。

## 💬 리뷰 요구사항 (선택)
리뷰 작성 후 계속 머지 안 하고 있으면 머지 부탁드립니다
