### PR TITLE
Feat: 美容室管理者カテゴリー関連API通信ロジックの作成

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		FA829E3A2B84C27000C3D7D1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FA829E392B84C27000C3D7D1 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,7 +65,6 @@
 		B964D164292AAFD5C3F60AB2 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		BF8F3F106DCF9122B47F07C5 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8EEEB968BF4C658107730D0 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		FA829E392B84C27000C3D7D1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,7 +134,6 @@
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
-				FA829E392B84C27000C3D7D1 /* GoogleService-Info.plist */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -265,7 +262,6 @@
 			files = (
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				FA829E3A2B84C27000C3D7D1 /* GoogleService-Info.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,7 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:GoogleService-Info.plist">
+      location = "group:../../../../Downloads/GoogleService-Info.plist">
    </FileRef>
    <FileRef
       location = "group:Runner.xcodeproj">

--- a/lib/salon/data/data_sources/admin/admin_category_data_source.dart
+++ b/lib/salon/data/data_sources/admin/admin_category_data_source.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:yjg/shared/constants/api_url.dart';
+
+class AdminCategoryDataSource {
+  String getApiUrl() {
+    // 상수 파일에서 가져온 apiURL 사용
+    return apiURL;
+  }
+
+  static final storage = FlutterSecureStorage(); // 토큰 담는 곳
+
+// * 카테고리 생성
+  Future<http.Response> postCategoryAPI(String categoryName) async {
+    final token = await storage.read(key: 'auth_token');
+    String url = '$apiURL/api/salon/category';
+    final body = jsonEncode({
+      'category' : categoryName
+    });
+
+    final response = await http.post(Uri.parse(url),
+        headers: <String, String>{
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: body);
+
+    if (response.statusCode == 201) {
+      return response;
+    } else {
+      debugPrint('카테고리 등록 실패: ${response.statusCode}, ${jsonDecode(utf8.decode(response.bodyBytes))}');
+      throw Exception('카테고리 등록에 실패했습니다.');
+    }
+  }
+
+  // * 카테고리 수정
+  Future<http.Response> patchCategoryAPI(
+      int categoryId, String? categoryNaame) async {
+    final token = await storage.read(key: 'auth_token');
+    String url = '$apiURL/api/salon/category';
+    final body = jsonEncode({
+      'category_id': categoryId,
+      'category': categoryNaame,
+    });
+
+    debugPrint('서비스 수정: $body');
+    final response = await http.patch(Uri.parse(url),
+        headers: <String, String>{
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: body);
+
+    debugPrint('카테고리 수정 결과: ${response.statusCode}, ${response.body}');
+
+    if (response.statusCode == 200) {
+      return response;
+    } else {
+      throw Exception('카테고리 수정에 실패했습니다.');
+    }
+  }
+
+  // * 카테고리 삭제
+  Future<http.Response> deleteCategoryAPI(int categoryId) async {
+    final token = await storage.read(key: 'auth_token');
+    String baseUrl = '$apiURL/api/salon/category';
+
+    final response = await http.delete(
+      Uri.parse('$baseUrl/$categoryId'),
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    debugPrint('카테고리 삭제 결과: ${response.statusCode}, ');
+
+    if (response.statusCode == 200) {
+      return response;
+    } else {
+      throw Exception('카테고리 삭제에 실패했습니다.');
+    }
+  }
+}

--- a/lib/salon/domain/entities/category.dart
+++ b/lib/salon/domain/entities/category.dart
@@ -1,0 +1,9 @@
+class SalonCategory {
+  final String? categoryName;
+  final int? categoryId;
+
+  SalonCategory({
+    this.categoryName,
+    this.categoryId,
+  });
+}

--- a/lib/salon/domain/usecases/admin_category_usecase.dart
+++ b/lib/salon/domain/usecases/admin_category_usecase.dart
@@ -1,0 +1,68 @@
+import 'package:yjg/salon/data/data_sources/admin/admin_category_data_source.dart';
+import 'package:yjg/salon/domain/entities/category.dart';
+
+class CategoryResult {
+  final bool isSuccess;
+  final String message;
+
+  CategoryResult({required this.isSuccess, required this.message});
+}
+
+class CategoryUseCases {
+  final AdminCategoryDataSource dataSource;
+
+  CategoryUseCases(this.dataSource);
+
+  Future<CategoryResult> createCategory(SalonCategory category) async {
+    try {
+      final response = await dataSource.postCategoryAPI(
+        category.categoryName!,
+      );
+
+      if (response.statusCode == 201) {
+        return CategoryResult(isSuccess: true, message: '서비스가 성공적으로 생성되었습니다.');
+      } else {
+        return CategoryResult(
+            isSuccess: false, message: '서비스 생성 실패: ${response.body}');
+      }
+    } catch (e) {
+      return CategoryResult(isSuccess: false, message: '서비스 생성 중 에러 발생: $e');
+    }
+  }
+
+  Future<CategoryResult> updateCategory(SalonCategory category) async {
+    try {
+      final response = await dataSource.patchCategoryAPI(
+        category.categoryId!,
+        category.categoryName,
+      );
+
+      if (response.statusCode == 200) {
+        return CategoryResult(
+            isSuccess: true, message: '카테고리 성공적으로 업데이트되었습니다.');
+      } else {
+        return CategoryResult(
+            isSuccess: false, message: '카테고리 수정 실패: ${response.body}');
+      }
+    } catch (e) {
+      return CategoryResult(isSuccess: false, message: '카테고리 수정 중 에러 발생: $e');
+    }
+  }
+
+  Future<CategoryResult> deleteCategory(SalonCategory category) async {
+    try {
+      final response = await dataSource.deleteCategoryAPI(
+        category.categoryId!,
+      );
+
+      if (response.statusCode == 200) {
+        return CategoryResult(isSuccess: true, message: '카테고리가 성공적으로 삭제되었습니다.');
+      } else {
+        return CategoryResult(
+            isSuccess: false, message: '카테고리 삭제 실패: ${response.body}');
+      }
+    } catch (e) {
+      return CategoryResult(isSuccess: false, message: '카테고리 삭제 중 에러 발생: $e');
+    }
+  }
+}

--- a/lib/salon/presentaion/pages/admin/admin_salon_price_list.dart
+++ b/lib/salon/presentaion/pages/admin/admin_salon_price_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/salon/presentaion/viewmodels/user_selection_viewmodel.dart';
+import 'package:yjg/salon/presentaion/widgets/admin/add_category_modal.dart';
 import 'package:yjg/salon/presentaion/widgets/admin/add_service_modal.dart';
 import 'package:yjg/salon/presentaion/widgets/admin/edit_service_button.dart';
 import 'package:yjg/salon/presentaion/widgets/filter_group_botton.dart';
@@ -20,7 +21,7 @@ class AdminSalonPricelist extends ConsumerWidget {
     String uniqueKey = "${selectedGender}_${selectedCategoryId}";
 
     return Scaffold(
-      appBar: BaseAppBar(title: "미용실 예약"),
+      appBar: BaseAppBar(title: "미용실 가격표"),
       bottomNavigationBar: const CustomBottomNavigationBar(),
       drawer: const BaseDrawer(),
       body: CustomSingleChildScrollView(
@@ -44,7 +45,7 @@ class AdminSalonPricelist extends ConsumerWidget {
                   ),
                   InkWell(
                     onTap: () {
-                      addServiceModal(context, ref, uniqueKey);
+                      addCategoryModal(context, ref, uniqueKey);
                     },
                     child: Text('추가',
                         style: TextStyle(
@@ -55,7 +56,7 @@ class AdminSalonPricelist extends ConsumerWidget {
                 ],
               ),
               SizedBox(
-                height: 15.0,
+                height: 10.0,
               ),
               Row(
                 children: [
@@ -66,11 +67,11 @@ class AdminSalonPricelist extends ConsumerWidget {
                   SizedBox(
                     width: 10.0,
                   ),
-                  FilterGroupButton(dataType: '성별')
+                  FilterGroupButton(dataType: '성별', uniqueKey: uniqueKey)
                 ],
               ),
               SizedBox(
-                height: 13.0,
+                height: 5.0,
               ),
               Row(
                 children: [
@@ -81,7 +82,7 @@ class AdminSalonPricelist extends ConsumerWidget {
                   SizedBox(
                     width: 10.0,
                   ),
-                  FilterGroupButton(dataType: '유형')
+                  FilterGroupButton(dataType: '유형', uniqueKey: uniqueKey)
                 ],
               ),
               SizedBox(

--- a/lib/salon/presentaion/pages/salon_booking_step_one.dart
+++ b/lib/salon/presentaion/pages/salon_booking_step_one.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/presentaion/viewmodels/user_selection_viewmodel.dart';
 import 'package:yjg/salon/presentaion/widgets/booking_service_button.dart';
 import 'package:yjg/salon/presentaion/widgets/filter_group_botton.dart';
 import 'package:yjg/shared/theme/palette.dart';
@@ -7,11 +9,16 @@ import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
 import 'package:yjg/shared/widgets/custom_singlechildscrollview.dart';
 
-class SalonBookingStepOne extends StatelessWidget {
+class SalonBookingStepOne extends ConsumerWidget {
   const SalonBookingStepOne({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userSelection = ref.watch(userSelectionProvider);
+    final selectedGender = userSelection.selectedGender;
+    final selectedCategoryId = userSelection.selectedCategoryId;
+    String uniqueKey = "${selectedGender}_${selectedCategoryId}";
+
     return Scaffold(
       appBar: BaseAppBar(title: "미용실 예약"),
       bottomNavigationBar: const CustomBottomNavigationBar(),
@@ -41,7 +48,7 @@ class SalonBookingStepOne extends StatelessWidget {
                   SizedBox(
                     width: 10.0,
                   ),
-                  FilterGroupButton(dataType: '성별')
+                  FilterGroupButton(dataType: '성별', uniqueKey: uniqueKey)
                 ],
               ),
               SizedBox(
@@ -56,7 +63,7 @@ class SalonBookingStepOne extends StatelessWidget {
                   SizedBox(
                     width: 10.0,
                   ),
-                  FilterGroupButton(dataType: '유형')
+                  FilterGroupButton(dataType: '유형', uniqueKey: uniqueKey)
                 ],
               ),
               SizedBox(

--- a/lib/salon/presentaion/pages/salon_price_list.dart
+++ b/lib/salon/presentaion/pages/salon_price_list.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/presentaion/viewmodels/user_selection_viewmodel.dart';
 import 'package:yjg/salon/presentaion/widgets/filter_group_botton.dart';
 import 'package:yjg/salon/presentaion/widgets/filter_service_list.dart';
 import 'package:yjg/shared/theme/palette.dart';
@@ -13,6 +14,10 @@ class SalonPriceList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+     final userSelection = ref.watch(userSelectionProvider);
+    final selectedGender = userSelection.selectedGender;
+    final selectedCategoryId = userSelection.selectedCategoryId;
+    String uniqueKey = "${selectedGender}_${selectedCategoryId}";
     return Scaffold(
       appBar: BaseAppBar(
         title: '가격표',
@@ -46,7 +51,7 @@ class SalonPriceList extends ConsumerWidget {
                     SizedBox(
                       width: 10.0,
                     ),
-                    FilterGroupButton(dataType: '성별')
+                    FilterGroupButton(dataType: '성별', uniqueKey: uniqueKey)
                   ],
                 ),
                 SizedBox(
@@ -62,7 +67,7 @@ class SalonPriceList extends ConsumerWidget {
                     SizedBox(
                       width: 10.0,
                     ),
-                    FilterGroupButton(dataType: '유형')
+                    FilterGroupButton(dataType: '유형', uniqueKey: uniqueKey)
                   ],
                 ),
                 SizedBox(

--- a/lib/salon/presentaion/widgets/admin/add_category_modal.dart
+++ b/lib/salon/presentaion/widgets/admin/add_category_modal.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/data/data_sources/admin/admin_category_data_source.dart';
+import 'package:yjg/salon/domain/entities/category.dart';
+import 'package:yjg/salon/domain/usecases/admin_category_usecase.dart';
+import 'package:yjg/salon/presentaion/viewmodels/category_viewmodel.dart';
+import 'package:yjg/shared/theme/palette.dart';
+import 'package:yjg/shared/widgets/custom_singlechildscrollview.dart';
+
+void addCategoryModal(BuildContext context, WidgetRef ref, String uniqueKey) {
+  final categoryUseCases = CategoryUseCases(AdminCategoryDataSource());
+
+  TextEditingController categoryController = TextEditingController();
+
+  showModalBottomSheet(
+    context: context,
+    builder: (BuildContext context) {
+      return StatefulBuilder(
+        // StatefulBuilder를 사용하여 상태를 관리
+        builder: (context, setState) {
+          return Container(
+            height: MediaQuery.of(context).size.height * 0.35,
+            padding: EdgeInsets.only(left: 20, right: 20, top: 30),
+            child: CustomSingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.max,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    '카테고리 등록',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  Text(
+                    '등록할 카테고리명을 입력해주세요. (성별 추가 불가)',
+                    style: TextStyle(
+                        color: Palette.textColor.withOpacity(0.7),
+                        fontSize: 14),
+                  ),
+                  SizedBox(height: 20),
+                  TextField(
+                    controller: categoryController,
+                    decoration: InputDecoration(
+                      labelText: '카테고리명',
+                      focusedBorder: UnderlineInputBorder(
+                        borderSide: BorderSide(color: Palette.mainColor),
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: 20),
+                  SizedBox(height: 10),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end, // 완료 버튼을 오른쪽으로 정렬
+                    children: [
+                      Expanded(
+                        child: ElevatedButton( 
+                          onPressed: () async {
+                            print(categoryController.text);
+                            SalonCategory newCategory = SalonCategory(
+                              categoryName: categoryController.text,
+                            );
+
+                            CategoryResult result = await categoryUseCases
+                                .createCategory(newCategory);
+
+                            if (result.isSuccess) {
+                              // 성공 시 서비스 리스트 상태 업데이트
+                              ref.refresh(categoryListProvider);
+
+                              // 성공 알림 표시
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text(result.message),
+                                  backgroundColor: Palette.mainColor,
+                                ),
+                              );
+
+                              // 모달 창 닫기
+                              Navigator.pop(context);
+                            } else {
+                              // 실패 시 실패 알림 표시
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text(result.message),
+                                  backgroundColor: Colors.red,
+                                ),
+                              );
+                            }
+                          },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Palette.mainColor,
+                            elevation: 0,
+                          ),
+                          child: Text(
+                            '카테고리 등록',
+                            style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: 40)
+                ],
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
+}

--- a/lib/salon/presentaion/widgets/admin/edit_category_modal.dart
+++ b/lib/salon/presentaion/widgets/admin/edit_category_modal.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/salon/data/data_sources/admin/admin_category_data_source.dart';
+import 'package:yjg/salon/domain/entities/category.dart';
+import 'package:yjg/salon/domain/usecases/admin_category_usecase.dart';
+import 'package:yjg/salon/presentaion/viewmodels/category_viewmodel.dart';
+import 'package:yjg/shared/theme/palette.dart';
+
+void editCategoryModal(
+  int? salonCategoryId,
+  String salonCategoryName,
+  BuildContext context,
+  WidgetRef ref,
+) {
+  TextEditingController categoryController =
+      TextEditingController(text: salonCategoryName);
+  final categoryUseCases = CategoryUseCases(AdminCategoryDataSource());
+
+  showModalBottomSheet(
+    context: context,
+    builder: (BuildContext context) {
+      return StatefulBuilder(
+        // StatefulBuilder를 사용하여 상태를 관리
+        builder: (context, setState) {
+          return Container(
+            height: MediaQuery.of(context).size.height * 0.32,
+            padding: EdgeInsets.all(20.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(
+                  '카테고리 수정',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+                Text(
+                  '수정할 카테고리명을 입력해주세요.',
+                  style: TextStyle(
+                      color: Palette.textColor.withOpacity(0.7), fontSize: 14),
+                ),
+                SizedBox(height: 20),
+                TextField(
+                  controller: categoryController,
+                  decoration: InputDecoration(
+                    labelText: '카테고리명',
+                    focusedBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(color: Palette.mainColor),
+                    ),
+                  ),
+                ),
+                SizedBox(height: 20),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextButton(
+                      child: Text(
+                        '카테고리 삭제',
+                        style: TextStyle(
+                            color: Palette.stateColor3,
+                            letterSpacing: -1.0,
+                            fontWeight: FontWeight.bold),
+                      ),
+                      onPressed: () async {
+                        SalonCategory deleteCategory = SalonCategory(
+                          categoryId: salonCategoryId,
+                        );
+
+                        CategoryResult result = await categoryUseCases
+                            .deleteCategory(deleteCategory);
+
+                        if (result.isSuccess) {
+                          // 성공 시 서비스 리스트 상태 업데이트
+                          ref.refresh(categoryListProvider);
+
+                          // 성공 알림 표시
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(result.message),
+                              backgroundColor: Palette.mainColor,
+                            ),
+                          );
+
+                          // 모달 창 닫기
+                          Navigator.pop(context);
+                        } else {
+                          // 실패 시 실패 알림 표시
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(result.message),
+                              backgroundColor: Colors.red,
+                            ),
+                          );
+                        }
+                      },
+                    ),
+                    ElevatedButton(
+                      onPressed: () async {
+                        SalonCategory updateCategory = SalonCategory(
+                          categoryName: categoryController.text,
+                          categoryId: salonCategoryId,
+                        );
+
+                        CategoryResult result = await categoryUseCases
+                            .updateCategory(updateCategory);
+
+                        if (result.isSuccess) {
+                          // 성공 시 서비스 리스트 상태 업데이트
+                          ref.refresh(categoryListProvider);
+
+                          // 성공 알림 표시
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(result.message),
+                              backgroundColor: Palette.mainColor,
+                            ),
+                          );
+
+                          // 모달 창 닫기
+                          Navigator.pop(context);
+                        } else {
+                          // 실패 시 실패 알림 표시
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(result.message),
+                              backgroundColor: Colors.red,
+                            ),
+                          );
+                        }
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Palette.mainColor,
+                        elevation: 0,
+                      ),
+                      child: Text(
+                        '완료',
+                        style: TextStyle(color: Colors.white),
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 30)
+              ],
+            ),
+          );
+        },
+      );
+    },
+  );
+}

--- a/lib/salon/presentaion/widgets/filter_group_botton.dart
+++ b/lib/salon/presentaion/widgets/filter_group_botton.dart
@@ -1,76 +1,106 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:group_button/group_button.dart';
 import 'package:yjg/salon/presentaion/viewmodels/category_viewmodel.dart';
 import 'package:yjg/salon/presentaion/viewmodels/user_selection_viewmodel.dart';
+import 'package:yjg/salon/presentaion/widgets/admin/add_category_modal.dart';
+import 'package:yjg/salon/presentaion/widgets/admin/edit_category_modal.dart';
 
 import 'package:yjg/shared/theme/palette.dart';
 
-class FilterGroupButton extends ConsumerWidget {
-  FilterGroupButton({Key? key, required this.dataType}) : super(key: key);
+class FilterGroupButton extends ConsumerStatefulWidget {
   final String dataType;
-  List<String> genderData = ['male', 'female'];
+  final uniqueKey;
+  FilterGroupButton({Key? key, required this.dataType, required this.uniqueKey})
+      : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // 비동기 데이터 로드
+  _FilterButtonsState createState() => _FilterButtonsState();
+}
+
+class _FilterButtonsState extends ConsumerState<FilterGroupButton> {
+  int? _selectedButtonIndex;
+  @override
+  Widget build(BuildContext context) {
     final categoryDataAsyncValue = ref.watch(categoryListProvider);
     final userSelection = ref.watch(userSelectionProvider);
 
-    // AsyncValue: 데이터가 로드중인지, 성공적으로 로드됐는지, 오류 발생했는지 등 다양한 상태를 나타내는 객체
-    // .when(): AsyncValue의 상태에 따라 다른 위젯을 표시(data, loading, error)
     return categoryDataAsyncValue.when(
       data: (Map<int, String> categoryData) {
-        // 데이터 로드 성공 시, UI 구성
         final categoryNames = categoryData.values.toList();
-        final buttons = dataType == '성별' ? genderData : categoryNames;
+        List<String> buttons =
+            widget.dataType == '성별' ? ['male', 'female'] : categoryNames;
 
-        // 기본 선택 인덱스 계산
-        int defaultSelectedIndex = dataType == '성별'
-            ? genderData.indexOf(userSelection.selectedGender)
-            : categoryData.keys
-                .toList()
-                .indexOf(userSelection.selectedCategoryId);
+        if (_selectedButtonIndex == null) {
+          _selectedButtonIndex = widget.dataType == '성별'
+              ? ['male', 'female'].indexOf(userSelection.selectedGender)
+              : categoryData.keys
+                  .toList()
+                  .indexOf(userSelection.selectedCategoryId);
+        }
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Wrap(
+            spacing: 4.0, // 버튼 간 가로 간격 줄임
+            runSpacing: 4.0, // 버튼 간 세로 간격 (Wrap이 여러 줄일 경우)
+            children: List.generate(
+              buttons.length,
+              (index) => ElevatedButton(
+                style: ButtonStyle(
+                  padding: MaterialStateProperty.all<EdgeInsets>(
+                      EdgeInsets.symmetric(vertical: 6.0, horizontal: 16.0)),
+                  minimumSize: MaterialStateProperty.all<Size>(
+                      Size(50, 30)), // 여기서 높이를 조정
 
-        // GroupButtonController 초기화
-        final controller = GroupButtonController(
-          selectedIndex: defaultSelectedIndex,
-        );
-
-        return GroupButton(
-          isRadio: true,
-          buttons: buttons,
-          onSelected: (val, i, selected) {
-            if (dataType == '성별') {
-              // 성별 선택을 상태로 저장
-              ref.read(userSelectionProvider.notifier).setSelectedGender(val);
-            } else {
-              // 카테고리 선택의 경우, val이 카테고리 이름이므로, 이를 id로 변환해야 함(카테고리 이름으로 카테고리 ID 찾기)
-              int? categoryId = categoryData.keys
-                  .firstWhere((k) => categoryData[k] == val, orElse: () => -1);
-              if (categoryId != null) {
-                // 유효한 카테고리 ID가 있다면 상태 업데이트
-                ref
-                    .read(userSelectionProvider.notifier)
-                    .setSelectedCategoryId(categoryId);
-              }
-              debugPrint(ref.read(userSelectionProvider).toString());
-            }
-          },
-          controller: controller,
-          options: GroupButtonOptions(
-            buttonWidth: 65.0,
-            buttonHeight: 25.0,
-            unselectedColor: Colors.grey[300],
-            unselectedTextStyle: TextStyle(
-              color: Colors.grey[600],
+                  backgroundColor: MaterialStateProperty.resolveWith<Color>(
+                    (Set<MaterialState> states) {
+                      if (_selectedButtonIndex == index)
+                        return Palette.mainColor; // 선택된 버튼 색상
+                      return Colors.grey[300]!; // 기본 버튼 색상
+                    },
+                  ),
+                  foregroundColor: MaterialStateProperty.resolveWith<Color>(
+                    (Set<MaterialState> states) {
+                      if (_selectedButtonIndex == index)
+                        return Colors.white; // 선택된 버튼 텍스트 색상
+                      return Colors.grey[600]!; // 기본 버튼 텍스트 색상
+                    },
+                  ),
+                  shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                    RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30.0),
+                    ),
+                  ),
+                ),
+                onLongPress: () {
+                  // 선택한 텍스트
+                  final selectedText = buttons[index];
+                  final int selectedCategoryId = categoryData.keys.elementAt(index);
+                  widget.dataType == "유형"
+                      ? editCategoryModal(selectedCategoryId, selectedText, context, ref)
+                      : null;
+                },
+                onPressed: () {
+                  setState(() {
+                    _selectedButtonIndex = index;
+                    // 선택 상태 업데이트 로직
+                    if (widget.dataType == '성별') {
+                      ref
+                          .read(userSelectionProvider.notifier)
+                          .setSelectedGender(buttons[index]);
+                    } else {
+                      ref
+                          .read(userSelectionProvider.notifier)
+                          .setSelectedCategoryId(
+                              categoryData.keys.elementAt(index));
+                    }
+                  });
+                },
+                child: Text(
+                  buttons[index],
+                  style: TextStyle(fontSize: 13.0, letterSpacing: -0.5),
+                ),
+              ),
             ),
-            selectedColor: Palette.mainColor,
-            elevation: 0,
-            selectedTextStyle: TextStyle(
-              color: Colors.white,
-            ),
-            borderRadius: BorderRadius.circular(30),
           ),
         );
       },


### PR DESCRIPTION
## 📣 연관된 이슈
> #138

## 📝 작업 내용
> 한국어
1. 미용실 관리자 가격표 페이지에 카테고리 등록, 수정, 삭제 API 통신 로직을 작성하였습니다.
2. 기능 확장성 문제로 가격표 페이지의 카테고리 버튼 구현에 사용된 `group_button2` 패키지를 제거하고 `ElevatedButton` 위젯으로 교체하였습니다.
3. 미용실 관리자 가격표 페이지 카테고리 API 통신과 관련된 커스텀 위젯을 구현하였습니다.

> 日本語
1. 美容室管理者の価格表ページにカテゴリー登録、修正、削除のAPI通信ロジックを作成しました。
2. 機能拡張性の問題で価格表ページのカテゴリーボタン実装に使用された`group_button2`パッケージを削除し、`ElevatedButton`ウィジェットに置き換えました。
3. 美容室管理者の価格表ページのカテゴリーAPI通信に関連するカスタムウィジェットを実装しました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
