### PR TITLE
Fix: メインページおよびDrawerに学生情報のローディング処理

### DIFF
--- a/lib/administration/presentaion/pages/admin_main.dart
+++ b/lib/administration/presentaion/pages/admin_main.dart
@@ -67,7 +67,7 @@ class _AdminMainState extends State<AdminMain> {
     return Scaffold(
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '행정'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       body: CustomSingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/administration/presentaion/pages/as_application.dart
+++ b/lib/administration/presentaion/pages/as_application.dart
@@ -120,7 +120,7 @@ class _AsApplicationState extends State<AsApplication> {
     return Scaffold(
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: 'AS요청'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       body: SingleChildScrollView(
         child: Column(
           children: [

--- a/lib/administration/presentaion/pages/as_page.dart
+++ b/lib/administration/presentaion/pages/as_page.dart
@@ -80,7 +80,7 @@ class _AsPageState extends State<AsPage> {
     return Scaffold(
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: 'AS요청'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       body: Column(
         children: [
           //AS 신청하기 버튼

--- a/lib/administration/presentaion/pages/meeting_room_main.dart
+++ b/lib/administration/presentaion/pages/meeting_room_main.dart
@@ -84,7 +84,7 @@ class _MeetingRoomMainState extends State<MeetingRoomMain> {
     return Scaffold(
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '회의실 예약'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       body: Column(
         children: [
           //AS 신청하기 버튼

--- a/lib/administration/presentaion/pages/notice.dart
+++ b/lib/administration/presentaion/pages/notice.dart
@@ -55,7 +55,7 @@ class _NoticeState extends State<Notice> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const BaseAppBar(title: '공지사항'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       bottomNavigationBar: const CustomBottomNavigationBar(),
       body: Column(
         children: [

--- a/lib/administration/presentaion/pages/sleepover.dart
+++ b/lib/administration/presentaion/pages/sleepover.dart
@@ -65,7 +65,7 @@ class _SleepoverState extends State<Sleepover> {
     return Scaffold(
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '외박/외출'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       body: Column(
         children: [
           SingleChildScrollView(

--- a/lib/administration/presentaion/pages/sleepover_application.dart
+++ b/lib/administration/presentaion/pages/sleepover_application.dart
@@ -72,7 +72,7 @@ class _SleepoverApplicationState extends State<SleepoverApplication> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const BaseAppBar(title: '외박/외출'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Column(

--- a/lib/as(admin)/presentation/pages/as_detail.dart
+++ b/lib/as(admin)/presentation/pages/as_detail.dart
@@ -154,7 +154,6 @@ class _AsDetailState extends State<AsDetail> {
 
     return Scaffold(
       appBar: BaseAppBar(title: 'AS관리'),
-      drawer: const BaseDrawer(),
       bottomNavigationBar: const CustomBottomNavigationBar(),
 
       // 수정, 삭제 버튼

--- a/lib/auth/data/data_resources/login_data_source.dart
+++ b/lib/auth/data/data_resources/login_data_source.dart
@@ -41,14 +41,13 @@ class LoginDataSource {
       String? token = tokenGenerated.accessToken; // 토큰값 추출
       String studentName = tokenGenerated.user!.name!; // 사용자 이름 추출
       String refreshToken = tokenGenerated.refreshToken!;
+      String studentNum = tokenGenerated.user!.studentId!;
+      
       if (token != null) {
         await storage.write(key: 'auth_token', value: token); // 토큰 저장
-        debugPrint('토큰 저장: $token');
         await storage.write(key: 'refresh_token', value: refreshToken);
-        debugPrint('리프레시 토큰 저장: $refreshToken');
-        ref
-            .read(studentNameProvider.notifier)
-            .setStudentName(studentName); // 사용자 이름 저장
+        await storage.write(key: 'name', value: studentName); // 사용자 이름 저장
+        await storage.write(key: 'student_num', value: studentNum);
       } else {
         throw Exception('토큰이 없습니다.');
       }

--- a/lib/auth/domain/usecases/login_usecase.dart
+++ b/lib/auth/domain/usecases/login_usecase.dart
@@ -25,7 +25,7 @@ class LoginUseCase {
     // 로그인 상태 업데이트
      // false: Student, true: Admin
     String adminPrivilege = ref.watch(adminPrivilegesProvider);
-    bool? isAdmin = await storage.read(key: 'isAdmin') == 'true' ? true : false;
+    bool? isAdmin = ref.watch(isAdminProvider);
 
     try {
       if (isAdmin == false) {

--- a/lib/auth/presentation/viewmodels/privilege_viewmodel.dart
+++ b/lib/auth/presentation/viewmodels/privilege_viewmodel.dart
@@ -22,4 +22,16 @@ final adminPrivilegesProvider = StateNotifierProvider<AdminPrivilegesNotifier, S
 });
 
 
-//     final privilege = watch(adminPrivilegesProvider);
+// isAdmin 상태를 관리하는 프로바이더
+class IsAdminNotifier extends StateNotifier<bool?> {
+  IsAdminNotifier() : super(null); // 초기값은 빈 문자열
+
+  void setStudentName(bool isAdmin) {
+    state = isAdmin;
+  }
+}
+
+final isAdminProvider = StateNotifierProvider<IsAdminNotifier, bool?>((ref) {
+  return IsAdminNotifier();
+});
+

--- a/lib/auth/presentation/viewmodels/user_viewmodel.dart
+++ b/lib/auth/presentation/viewmodels/user_viewmodel.dart
@@ -43,16 +43,3 @@ final adminIdProvider = StateNotifierProvider<AdminIdNotifier, int>((ref) {
   return AdminIdNotifier();
 });
 
-
-// 학생 이름 상태 업데이트를 위한 StudentNameProvider
-class StudentNameNotifier extends StateNotifier<String> {
-  StudentNameNotifier() : super(''); // 초기값은 빈 문자열
-
-  void setStudentName(String newStudentName) {
-    state = newStudentName;
-  }
-}
-
-final studentNameProvider = StateNotifierProvider<StudentNameNotifier, String>((ref) {
-  return StudentNameNotifier();
-});

--- a/lib/auth/presentation/widgets/login_button.dart
+++ b/lib/auth/presentation/widgets/login_button.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:yjg/auth/domain/usecases/login_usecase.dart';
+import 'package:yjg/auth/presentation/viewmodels/privilege_viewmodel.dart';
 import 'package:yjg/shared/theme/palette.dart';
 
 class LoginButton extends ConsumerWidget {
@@ -25,10 +26,10 @@ class LoginButton extends ConsumerWidget {
 
           // 현재 라우트가 '/login_student'인 경우 isAdminProvider의 상태를 false로 설정(라우터에 따른 API 통신 변경)
           currentRouteName == '/login_student'
-              ? storage.write(key: 'isAdmin', value: 'false') 
-              : storage.write(key: 'isAdmin', value: 'true'); 
+              ? ref.read(isAdminProvider.notifier).state = false
+              : ref.read(isAdminProvider.notifier).state = true; 
 
-          debugPrint('유형: ${await storage.read(key: 'isAdmin')}, 현재 라우트: $currentRouteName');
+          debugPrint('유형: ${ref.watch(isAdminProvider)}, 현재 라우트: $currentRouteName');
           // LoginUseCase 인스턴스 생성
           final loginUseCase =
               LoginUseCase(ref: ref);

--- a/lib/bus/presentaion/pages/bus_main.dart
+++ b/lib/bus/presentaion/pages/bus_main.dart
@@ -25,7 +25,7 @@ class _BusMainState extends ConsumerState<BusMain> {
     return Scaffold(
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '버스'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       body: SingleChildScrollView( // SingleChildScrollView 추가하여 스크롤 가능하도록 수정
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/bus/presentaion/pages/bus_qr.dart
+++ b/lib/bus/presentaion/pages/bus_qr.dart
@@ -17,7 +17,7 @@ class _BusQrState extends State<BusQr> {
     return Scaffold(
       backgroundColor: const Color.fromARGB(255, 29, 127, 159),
       appBar: BaseAppBar(title: '버스QR'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       bottomNavigationBar: CustomBottomNavigationBar(),
       body: Column(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/bus/presentaion/pages/bus_schedule.dart
+++ b/lib/bus/presentaion/pages/bus_schedule.dart
@@ -17,7 +17,7 @@ class BusSchedule extends ConsumerWidget {
 
     return Scaffold(
       appBar: const BaseAppBar(title: '버스 시간표'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       bottomNavigationBar: const CustomBottomNavigationBar(),
       body: Padding(
         padding: const EdgeInsets.all(16.0),

--- a/lib/dashboard/presentaion/pages/dashboard_main.dart
+++ b/lib/dashboard/presentaion/pages/dashboard_main.dart
@@ -15,7 +15,7 @@ class DashboardMain extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const BaseAppBar(),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       bottomNavigationBar: const CustomBottomNavigationBar(),
       body: CustomSingleChildScrollView(
         child: Column(

--- a/lib/dashboard/presentaion/widgets/rounded_box.dart
+++ b/lib/dashboard/presentaion/widgets/rounded_box.dart
@@ -1,15 +1,36 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:yjg/auth/presentation/viewmodels/user_viewmodel.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:yjg/shared/widgets/custom_rounded_button.dart';
 import 'package:yjg/shared/theme/palette.dart';
 
-class RoundedBox extends ConsumerWidget {
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // 학생 이름
-    final studentName = ref.watch(studentNameProvider);
+class RoundedBox extends StatefulWidget {
+  RoundedBox({super.key});
+  String? name;
 
+  @override
+  State<RoundedBox> createState() => _RoundedBoxState();
+}
+
+class _RoundedBoxState extends State<RoundedBox> {
+  @override
+  void initState() {
+    getUserInfo();
+
+    super.initState();
+  }
+
+  // 로컬스토리지에 저장된 사용자 정보를 불러오기
+  Future<void> getUserInfo() async {
+    final storage = FlutterSecureStorage();
+    String? name = await storage.read(key: 'name');
+    debugPrint('name: $name');
+    setState(() {
+      widget.name = name;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
       width: double.infinity, // 상자의 너비
       height: 170, // 상자의 높이
@@ -39,8 +60,9 @@ class RoundedBox extends ConsumerWidget {
                 mainAxisAlignment: MainAxisAlignment.start, // 위젯들을 위쪽으로 정렬
                 children: <Widget>[
                   SizedBox(height: 10),
-                  Text(studentName,
-                    style: 
+                  Text(
+                    widget.name ?? '정보 없음',
+                    style:
                         TextStyle(color: Palette.backgroundColor, fontSize: 18),
                   ),
                   SizedBox(height: 10), // 텍스트 - 버튼 간격
@@ -50,12 +72,14 @@ class RoundedBox extends ConsumerWidget {
                       CustomRoundedButton(
                           onPressed: () {
                             Navigator.pushNamed(context, '/bus_qr');
-                          }, buttonText: '버스 QR'),
+                          },
+                          buttonText: '버스 QR'),
                       SizedBox(width: 8),
                       CustomRoundedButton(
                           onPressed: () {
                             Navigator.pushNamed(context, '/meal_qr');
-                          }, buttonText: '식수 QR'),
+                          },
+                          buttonText: '식수 QR'),
                     ],
                   ),
                 ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,6 @@ import 'package:yjg/salon/presentaion/pages/salon_my_book.dart';
 import 'package:yjg/salon/presentaion/pages/salon_price_list.dart';
 import 'package:yjg/setting/setting_page.dart';
 import 'package:yjg/shared/service/device_info.dart';
-// import 'package:yjg/shared/service/load_set_student_name.dart';
 import 'package:yjg/shared/service/token_decoder.dart';
 import 'package:yjg/shared/theme/theme.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -47,7 +46,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
+  WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+  FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
+
   final storage = FlutterSecureStorage();
   await dotenv.load(fileName: ".env");
 
@@ -58,8 +59,6 @@ void main() async {
   final token = await storage.read(key: 'auth_token');
   final autoLoginStr = await storage.read(key: 'auto_login') ?? 'false';
   final refreshToken = await storage.read(key: 'refresh_token');
-
-
   debugPrint('token: $token');
   debugPrint('refreshToken: $refreshToken');
   String? userType = await storage.read(key: 'userType');
@@ -67,7 +66,6 @@ void main() async {
   if (token != null) {
     bool hasExpired = JwtDecoder.isExpired(token);
     tokenDecoder(token, autoLoginStr, hasExpired);
-
 
     // 자동로그인이 true이고, 토큰이 만료되지 않았을 경우
     if (autoLoginStr == 'true' && hasExpired == false) {
@@ -176,14 +174,14 @@ class MyApp extends ConsumerWidget {
         '/sleepover': (context) => Sleepover(),
         '/sleepover_application': (context) => SleepoverApplication(),
         '/meeting_room_app': (context) => MeetingRoomApp(),
-        '/meeting_room_main':(context) => MeetingRoomMain(),
+        '/meeting_room_main': (context) => MeetingRoomMain(),
 
         // AS 관련(관리자)
         '/as_admin': (context) => AsMain(),
         '/as_detail': (context) => AsDetail(),
 
         // 설정
-        '/setting' : (context) => SettingPage(),
+        '/setting': (context) => SettingPage(),
       },
     );
   }

--- a/lib/restaurant/presentaion/pages/meal_application.dart
+++ b/lib/restaurant/presentaion/pages/meal_application.dart
@@ -198,7 +198,7 @@ class _MealApplicationState extends ConsumerState<MealApplication> {
     if (application == false) {
       return Scaffold(
         appBar: const BaseAppBar(title: '식수 신청'),
-        drawer: const BaseDrawer(),
+        drawer: BaseDrawer(),
         bottomNavigationBar: const CustomBottomNavigationBar(),
         body: CustomSingleChildScrollView(
           child: Column(
@@ -395,7 +395,7 @@ class _MealApplicationState extends ConsumerState<MealApplication> {
     else if (application == true && deposit == false) {
       return Scaffold(
         appBar: const BaseAppBar(title: '식수 신청'),
-        drawer: const BaseDrawer(),
+        drawer: BaseDrawer(),
         bottomNavigationBar: const CustomBottomNavigationBar(),
         body: SingleChildScrollView(
           child: Column(
@@ -460,7 +460,7 @@ class _MealApplicationState extends ConsumerState<MealApplication> {
     else {
       return Scaffold(
         appBar: const BaseAppBar(title: '식수 신청'),
-        drawer: const BaseDrawer(),
+        drawer: BaseDrawer(),
         bottomNavigationBar: const CustomBottomNavigationBar(),
         body: SingleChildScrollView(
           child: Column(

--- a/lib/restaurant/presentaion/pages/meal_qr.dart
+++ b/lib/restaurant/presentaion/pages/meal_qr.dart
@@ -23,7 +23,7 @@ class _MealQrState extends State<MealQr> {
     return Scaffold(
       backgroundColor: const Color.fromARGB(255, 29, 127, 159),
       appBar: BaseAppBar(title: '식수QR'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       bottomNavigationBar: CustomBottomNavigationBar(),
       body: Column(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/restaurant/presentaion/pages/menu_list.dart
+++ b/lib/restaurant/presentaion/pages/menu_list.dart
@@ -100,7 +100,7 @@ class _MenuListState extends State<MenuList> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const BaseAppBar(title: '식단표'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       bottomNavigationBar: const CustomBottomNavigationBar(),
       body: SingleChildScrollView(
         // 스크롤 가능한 구조로 변경

--- a/lib/restaurant/presentaion/pages/restaurant_main.dart
+++ b/lib/restaurant/presentaion/pages/restaurant_main.dart
@@ -105,7 +105,7 @@ class _RestaurantMainState extends State<RestaurantMain> {
     return Scaffold(
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '식수'),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       body: CustomSingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/restaurant/presentaion/pages/weekend_meal.dart
+++ b/lib/restaurant/presentaion/pages/weekend_meal.dart
@@ -31,7 +31,7 @@ class _WeekendMealState extends State<WeekendMeal> {
     if (mealWeekend == false) {
       return Scaffold(
         appBar: BaseAppBar(title: '주말식수'),
-        drawer: const BaseDrawer(),
+        drawer: BaseDrawer(),
         bottomNavigationBar: CustomBottomNavigationBar(),
         body: CustomSingleChildScrollView(
           child: Column(
@@ -399,7 +399,7 @@ class _WeekendMealState extends State<WeekendMeal> {
     else if (mealWeekend = true && mealWeekendDeposit == false) {
       return Scaffold(
         appBar: BaseAppBar(title: '주말식수'),
-        drawer: const BaseDrawer(),
+        drawer: BaseDrawer(),
         bottomNavigationBar: CustomBottomNavigationBar(),
         body: SingleChildScrollView(
           child: Column(
@@ -690,7 +690,7 @@ class _WeekendMealState extends State<WeekendMeal> {
     else {
       return Scaffold(
         appBar: BaseAppBar(title: '주말식수'),
-        drawer: const BaseDrawer(),
+        drawer: BaseDrawer(),
         bottomNavigationBar: CustomBottomNavigationBar(),
         body: SingleChildScrollView(
           child: Column(

--- a/lib/salon/presentaion/pages/admin/admin_salon_price_list.dart
+++ b/lib/salon/presentaion/pages/admin/admin_salon_price_list.dart
@@ -23,7 +23,7 @@ class AdminSalonPricelist extends ConsumerWidget {
     return Scaffold(
       appBar: BaseAppBar(title: "미용실 가격표"),
       bottomNavigationBar: const CustomBottomNavigationBar(),
-      drawer: const BaseDrawer(),
+      drawer: BaseDrawer(),
       body: CustomSingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.all(20.0),

--- a/lib/salon/presentaion/pages/salon_booking_step_one.dart
+++ b/lib/salon/presentaion/pages/salon_booking_step_one.dart
@@ -5,7 +5,6 @@ import 'package:yjg/salon/presentaion/widgets/booking_service_button.dart';
 import 'package:yjg/salon/presentaion/widgets/filter_group_botton.dart';
 import 'package:yjg/shared/theme/palette.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
-import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
 import 'package:yjg/shared/widgets/custom_singlechildscrollview.dart';
 
@@ -22,7 +21,6 @@ class SalonBookingStepOne extends ConsumerWidget {
     return Scaffold(
       appBar: BaseAppBar(title: "미용실 예약"),
       bottomNavigationBar: const CustomBottomNavigationBar(),
-      drawer: const BaseDrawer(),
       body: CustomSingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.all(20.0),

--- a/lib/salon/presentaion/pages/salon_booking_step_two.dart
+++ b/lib/salon/presentaion/pages/salon_booking_step_two.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/salon/presentaion/widgets/booking_calendar.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
-import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
 import 'package:yjg/shared/widgets/custom_singlechildscrollview.dart';
 
@@ -14,7 +13,6 @@ class SalonBookingStepTwo extends ConsumerWidget {
     return Scaffold(
       appBar: BaseAppBar(title: "미용실 예약"),
       bottomNavigationBar: const CustomBottomNavigationBar(),
-      drawer: const BaseDrawer(),
       body: CustomSingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.all(20.0),

--- a/lib/salon/presentaion/pages/salon_main.dart
+++ b/lib/salon/presentaion/pages/salon_main.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/salon/presentaion/viewmodels/notice_viewmodel.dart';
 import 'package:yjg/salon/presentaion/viewmodels/reservations_viewmodel.dart';
 import 'package:yjg/shared/theme/palette.dart';
-import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/blue_main_rounded_box.dart';
 import 'package:yjg/shared/widgets/notice_box.dart';
 import 'package:yjg/shared/widgets/white_main_rounded_box.dart';
@@ -36,7 +35,6 @@ class _SalonMainState extends ConsumerState<SalonMain> {
     return Scaffold(
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '미용실'),
-      drawer: const BaseDrawer(),
       body: Stack(
         children: [
           AnimatedSwitcher( // 두 개의 비동기 상태를 모두 로딩이 완료되면 페이지 내용을 표시

--- a/lib/salon/presentaion/pages/salon_my_book.dart
+++ b/lib/salon/presentaion/pages/salon_my_book.dart
@@ -2,7 +2,6 @@ import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:yjg/salon/presentaion/widgets/my_booking_list.dart";
 import "package:yjg/shared/widgets/base_appbar.dart";
-import "package:yjg/shared/widgets/base_drawer.dart";
 import "package:yjg/shared/widgets/bottom_navigation_bar.dart";
 
 class SalonMyBook extends ConsumerWidget {
@@ -13,7 +12,6 @@ class SalonMyBook extends ConsumerWidget {
     return Scaffold(
       appBar: BaseAppBar(title: "예약 내역"),
       bottomNavigationBar: const CustomBottomNavigationBar(),
-      drawer: const BaseDrawer(),
       body: MyBookingList(),
     );
   }

--- a/lib/salon/presentaion/pages/salon_price_list.dart
+++ b/lib/salon/presentaion/pages/salon_price_list.dart
@@ -5,7 +5,6 @@ import 'package:yjg/salon/presentaion/widgets/filter_group_botton.dart';
 import 'package:yjg/salon/presentaion/widgets/filter_service_list.dart';
 import 'package:yjg/shared/theme/palette.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
-import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
 import 'package:yjg/shared/widgets/custom_singlechildscrollview.dart';
 
@@ -23,7 +22,6 @@ class SalonPriceList extends ConsumerWidget {
         title: '가격표',
       ),
       bottomNavigationBar: const CustomBottomNavigationBar(),
-      drawer: const BaseDrawer(),
       body: CustomSingleChildScrollView(
         child: SizedBox(
           child: Padding(

--- a/lib/shared/widgets/base_appbar.dart
+++ b/lib/shared/widgets/base_appbar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:yjg/auth/presentation/viewmodels/privilege_viewmodel.dart';
 import 'package:yjg/shared/service/auth_service.dart';
 
 class BaseAppBar extends ConsumerWidget implements PreferredSizeWidget {
@@ -13,11 +14,10 @@ class BaseAppBar extends ConsumerWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final storage = FlutterSecureStorage();
 
     Future<bool> getIsAdmin() async {
-      final isAdminString = await storage.read(key: 'isAdmin') == 'true' ? true : false;
-      return isAdminString;
+      final isAdmin = ref.watch(isAdminProvider);
+      return isAdmin!;
     }
 
     Widget titleWidget = title != null


### PR DESCRIPTION
## 📣 연관된 이슈
> #122

## 📝 작업 내용
> 한국어
1. 메인 페이지 및 Drawer에 학생 이름과 학번이 제대로 로딩되지 않는 버그가 있어, 해당 버그를 수정하였습니다.
2. 1번의 진행에 따라 Drawer 파일을 `StatefulWidget`으로 변경하였습니다.
3. Drawer를 `StatefulWidget`으로 변경함에 따라, 기존 페이지 파일에서 `const BaseApp()`로 사용되고 있던 것을 `BaseApp()`로 교체하였습니다.
4. 관리자 여부가 제대로 관리되지 않는 버그를 발견하여, 해당 버그를 `riverpod provider`를 통해 관리하도록 수정하였습니다.
5. 그 외 `main.dart`에 `FlutterNativeSplash.preserve` 구문을 추가, 불필요한 코드를 삭제하였습니다.


> 일본어
1. メインページおよびDrawerで学生の名前と学生番号が正しくロードされないバグがあり、そのバグを修正しました。
2. 1の進行に伴い、Drawerファイルを`StatefulWidget`に変更しました。
3. Drawerを`StatefulWidget`に変更したことで、既存のページファイルで`const BaseApp()`として使用されていたものを`BaseApp()`に置き換えました。
4. 管理者かどうかが正しく管理されないバグを発見し、そのバグを`riverpod provider`を通じて管理するように修正しました。
5. その他、`main.dart`にFlutterNativeSplash.preserve文を追加し、不要なコードを削除しました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
