### PR TITLE
Feat: トークンの有無に応じた処理、ヘッダー設定ロジックの追加

### DIFF
--- a/lib/as(admin)/data/data_sources/as_data_source.dart
+++ b/lib/as(admin)/data/data_sources/as_data_source.dart
@@ -1,21 +1,19 @@
-import 'dart:convert';
-
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:http/http.dart' as http;
 import 'package:yjg/shared/constants/api_url.dart';
+import 'package:yjg/shared/service/interceptor.dart';
 
 class AsDataSource {
-  String getApiUrl() {
-    // 상수 파일에서 가져온 apiURL 사용
-    return apiURL;
-  }
-
+  static final Dio dio = Dio();
   static final storage = FlutterSecureStorage(); // 토큰 담는 곳
 
-// * as 데이터
-  Future<http.Response> getAsDataAPI(int status, int page) async {
-    final token = await storage.read(key: 'auth_token');
+  AsDataSource() {
+    dio.interceptors.add(DioInterceptor(dio));
+  }
+
+  // * as 데이터
+  Future<Response> getAsDataAPI(int status, int page) async {
     String url = '$apiURL/api/after-service';
 
     debugPrint('status: $status, page: $page');
@@ -25,19 +23,15 @@ class AsDataSource {
       'page': page.toString(),
     };
 
-    Uri uri = Uri.parse(url).replace(queryParameters: queryParams);
+    try {
+      final response = await dio.get(
+        url,
+        queryParameters: queryParams,
+      );
 
-    debugPrint('uri: $uri');
-    final response = await http.get(
-      uri,
-      headers: <String, String>{
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer $token',
-      },
-    );
-    if (response.statusCode == 200) {
+      debugPrint('response: $response');
       return response;
-    } else {
+    } catch (e) {
       throw Exception('AS 데이터 가져오기에 실패했습니다.');
     }
   }

--- a/lib/as(admin)/data/data_sources/as_status_data_source.dart
+++ b/lib/as(admin)/data/data_sources/as_status_data_source.dart
@@ -1,33 +1,24 @@
-
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:http/http.dart' as http;
 import 'package:yjg/shared/constants/api_url.dart';
 
 class StatusDataSource {
-  String getApiUrl() {
-    // 상수 파일에서 가져온 apiURL 사용
-    return apiURL;
-  }
+  static final Dio dio = Dio();
 
   static final storage = FlutterSecureStorage(); // 토큰 담는 곳
 
-// * 상태 변경
-  Future<http.Response> patchStatusAPI(int serviceId) async {
-    final token = await storage.read(key: 'auth_token');
+  // * 상태 변경
+  Future<Response> patchStatusAPI(int serviceId) async {
     String url = '$apiURL/api/after-service/status/${serviceId.toString()}';
 
-    final response = await http.patch(Uri.parse(url),
-        headers: <String, String>{
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer $token',
-        },);
-
-    debugPrint('상태 변경 결과: ${response.statusCode}, ${response.body}');
-    if (response.statusCode == 200) {
+    try {
+      final response = await dio.patch(url);
       return response;
-    } else {
+    } catch (e) {
+      debugPrint('통신 결과: $e');
       throw Exception('상태 변경에 실패했습니다.');
+
     }
   }
 }

--- a/lib/as(admin)/data/models/as_comment.dart
+++ b/lib/as(admin)/data/models/as_comment.dart
@@ -1,6 +1,6 @@
 class AfterServiceComment {
   final int id;
-  final int adminId;
+  final int userId;
   final int afterServiceId;
   final String comment;
   final String createdAt;
@@ -8,7 +8,7 @@ class AfterServiceComment {
 
   AfterServiceComment({
     required this.id,
-    required this.adminId,
+    required this.userId,
     required this.afterServiceId,
     required this.comment,
     required this.createdAt,
@@ -17,19 +17,19 @@ class AfterServiceComment {
 
   factory AfterServiceComment.fromJson(Map<String, dynamic> json) {
     return AfterServiceComment(
-      id: json['id'],
-      adminId: json['admin_id'],
-      afterServiceId: json['after_service_id'],
-      comment: json['comment'],
-      createdAt: json['created_at'],
-      updatedAt: json['updated_at'],
+      id: json['id'] ?? 0,
+      userId: json['user_id'] ?? 0,
+      afterServiceId: json['after_service_id'] ?? 0,
+      comment: json['comment'] ?? '',
+      createdAt: json['created_at'] ?? '',
+      updatedAt: json['updated_at'] ?? '',
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
       'id': id,
-      'admin_id': adminId,
+      'user_id': userId,
       'after_service_id': afterServiceId,
       'comment': comment,
       'created_at': createdAt,

--- a/lib/as(admin)/domain/usecases/as_status_usecase.dart
+++ b/lib/as(admin)/domain/usecases/as_status_usecase.dart
@@ -24,7 +24,7 @@ class StatusUseCases {
         return StatusResult(isSuccess: true, message: '상태가 성공적으로 변경되었습니다.');
       } else {
         return StatusResult(
-            isSuccess: false, message: '상태 변경 실패: ${response.body}');
+            isSuccess: false, message: '상태 변경 실패: ${response.data}');
       }
     } catch (e) {
       return StatusResult(isSuccess: false, message: '상태 변경 중 에러 발생: $e');

--- a/lib/as(admin)/presentation/pages/as_detail.dart
+++ b/lib/as(admin)/presentation/pages/as_detail.dart
@@ -5,7 +5,6 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:yjg/administration/presentaion/widgets/std_as_floating_button.dart';
 import 'package:yjg/as(admin)/presentation/widgets/admin_as_floating_button.dart';
-import 'package:yjg/auth/presentation/viewmodels/privilege_viewmodel.dart';
 import 'package:yjg/shared/constants/api_url.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
@@ -40,10 +39,10 @@ class _AsDetailState extends ConsumerState<AsDetail> {
 
   // storage에서 isAdmin 값을 읽어와서 상태를 업데이트하는 메소드
   Future<void> _checkIfAdmin() async {
-    bool? isAdminValue = ref.watch(isAdminProvider);
+    String? isAdminValue = await storage.read(key: 'isAdmin');
 
     setState(() {
-      isAdminValue == true ? isAdmin = true : isAdmin = false;
+      isAdmin = isAdminValue == 'true';
       debugPrint('관리자여부: $isAdmin');
     });
   }

--- a/lib/as(admin)/presentation/viewmodels/as_viewmodel.dart
+++ b/lib/as(admin)/presentation/viewmodels/as_viewmodel.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/as(admin)/data/data_sources/as_data_source.dart';
@@ -25,7 +23,7 @@ class AsDataNotifier extends StateNotifier<AsyncValue<AfterServiceResponse>> {
     try {
       final page = ref.read(currentPageProvider);
       final response = await AsDataSource().getAsDataAPI(status, page);
-      final data = AfterServiceResponse.fromJson(jsonDecode(response.body));
+      final data = AfterServiceResponse.fromJson(response.data);
       state = AsyncValue.data(data);
     } catch (e, s) {
       debugPrint('fetchAsData error: $e, stack trace: $s'); // 오류와 스택 트레이스 출력

--- a/lib/as(admin)/presentation/viewmodels/comment_viewmodel.dart
+++ b/lib/as(admin)/presentation/viewmodels/comment_viewmodel.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/as(admin)/data/data_sources/as_comment_data_source.dart';
@@ -18,7 +17,7 @@ class CommentViewModel
     try {
       final dataSource = AsCommentDataSource();
       final response = await dataSource.getCommentAPI(serviceId);
-      final data = json.decode(response.data);
+      final data = response.data;
       final List<dynamic> commentsJson = data['after_service_comments'];
       // 'after_service_comments' 키의 값을 List<AfterServiceComment>로 변환
       final List<AfterServiceComment> comments = commentsJson

--- a/lib/auth/presentation/viewmodels/privilege_viewmodel.dart
+++ b/lib/auth/presentation/viewmodels/privilege_viewmodel.dart
@@ -30,26 +30,6 @@ final adminPrivilegesProvider = StateNotifierProvider<AdminPrivilegesNotifier, S
   return AdminPrivilegesNotifier();
 });
 
-
-
-// isAdmin 상태를 관리하는 프로바이더
-class IsAdminNotifier extends StateNotifier<bool> {
-  IsAdminNotifier() : super(false); // 초기값은 false
-
-  void checkAdmin(User user) {
-    // 권한 리스트를 순회하면서 admin 권한이 있는지 확인
-    for (final privilege in user.privileges ?? []) {
-      if (privilege.privilege == 'admin') {
-        state = true; // 관리자 권한 발견
-        return;
-      }
-    }
-    state = false; // 관리자 권한이 없음
-  }
-}
-
-final isAdminProvider = StateNotifierProvider<IsAdminNotifier, bool>((ref) {
-  return IsAdminNotifier();
-});
+final isAdminProvider = StateProvider<bool?>((ref) => null);
 
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ void main() async {
   // 초기 라우터 설정
   final initialRoute = await AuthService().getInitialRoute();
   debugPrint('initialRoute: $initialRoute');
+
   // 스플래시 스크린 제거
   FlutterNativeSplash.remove();
 

--- a/lib/shared/service/auth_service.dart
+++ b/lib/shared/service/auth_service.dart
@@ -13,7 +13,9 @@ class AuthService {
     final refreshToken = await storage.read(key: 'refresh_token');
     final userType = await storage.read(key: 'userType');
 
-    debugPrint('autoLoginStr: $autoLoginStr');
+    debugPrint('액세스 토큰: $token');
+    debugPrint('리프레시 토큰: $refreshToken');
+
     debugPrint('userType: $userType');
 
     if (autoLoginStr != 'true' || (token == null && refreshToken == null)) {
@@ -24,12 +26,16 @@ class AuthService {
       debugPrint('token is expired');
       await LoginDataSource().getRefreshTokenAPI();
       final newToken = await storage.read(key: 'auth_token');
-      return newToken != null && !JwtDecoder.isExpired(newToken)
-          ? AppRoutes.getInitialRouteBasedOnUserType(userType)
-          : '/login_student';
+      debugPrint(
+          'newToken 유효성 여부: ${JwtDecoder.isExpired(newToken ?? 'null')}');
+      if (newToken != null && !JwtDecoder.isExpired(newToken)) {
+        final initRoute = AppRoutes.getInitialRouteBasedOnUserType(userType);
+        debugPrint('initRoute: $initRoute');
+        return initRoute;
+      }
+      return '/login_student';
     }
 
     return AppRoutes.getInitialRouteBasedOnUserType(userType);
   }
 }
-

--- a/lib/shared/service/interceptor.dart
+++ b/lib/shared/service/interceptor.dart
@@ -18,19 +18,25 @@ class DioInterceptor extends Interceptor {
 
   @override
   // 요청 전송 전에 요청을 가로채고 처리
+  @override
   Future<void> onRequest(
       RequestOptions options, RequestInterceptorHandler handler) async {
-    // 인증 토큰을 가져옴
-    final token = await getToken();
-
-    // 토큰이 있을 경우 헤더에 추가
-    if (token != null) {
-      options.headers.addAll({
-        "Content-Type": "application/json",
-        "Authorization": "Bearer $token",
-      });
+    if (options.data is FormData) {
+      // 폼 데이터 요청인 경우
+      options.headers["Content-Type"] = "multipart/form-data";
+    } else {
+      // JSON 요청인 경우 (기본)
+      options.headers["Content-Type"] = "application/json";
     }
-    // 요청을 계속 진행
+
+    // 인증 토큰이 필요한 경우 헤더에 추가
+    if (options.extra["noAuth"] != true) {
+      final token = await getToken();
+      if (token != null) {
+        options.headers["Authorization"] = "Bearer $token";
+      }
+    }
+
     return super.onRequest(options, handler);
   }
 

--- a/lib/shared/widgets/base_appbar.dart
+++ b/lib/shared/widgets/base_appbar.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:yjg/auth/presentation/viewmodels/privilege_viewmodel.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:yjg/shared/service/logout_service.dart';
 
 class BaseAppBar extends ConsumerWidget implements PreferredSizeWidget {
@@ -13,10 +13,11 @@ class BaseAppBar extends ConsumerWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final storage = FlutterSecureStorage();
 
     Future<bool> getIsAdmin() async {
-      final isAdmin = ref.watch(isAdminProvider);
-      return isAdmin!;
+      final isAdmin = await storage.read(key: 'isAdmin');
+      return isAdmin == 'true';
     }
 
     Widget titleWidget = title != null
@@ -45,7 +46,9 @@ class BaseAppBar extends ConsumerWidget implements PreferredSizeWidget {
           centerTitle: true,
           leading: isAdmin
               ? IconButton(
-                  onPressed: () {LogoutService().logout(context, ref);}, 
+                  onPressed: () {
+                    LogoutService().logout(context, ref);
+                  },
                   icon: const Icon(
                     Icons.logout_outlined,
                     color: Colors.white,


### PR DESCRIPTION
## 📣 연관된 이슈
> #192 

## 📝 작업 내용
> 한국어
1. Dio 인터셉터에 토큰 유무 처리, Form Data 헤더 설정을 하였습니다. (기본 헤더는 `application/json`로 설정되어 있음)
2. AS 관리자 페이지 관련 API 로직의 리팩토링이 이루어졌습니다. (AS 댓글 관련 API, 상태 변경 API, AS 리스트 반환 API)
3. 관리자 관련 로직의 일부 수정이 이루어졌습니다.

> 日本語
1. Dio インターセプターにトークンの有無に応じた処理とForm Dataヘッダーの設定を行いました。（デフォルトヘッダーは`application/json`に設定されています。）
2. AS管理者ページ関連のAPIロジックのリファクタリングが行われました。（ASコメント関連API、ステータス変更API、ASリスト返却API）
3. 管理者関連のロジックの一部が修正されました。 

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
