### PR TITLE
Feat: パスワードリセットロジックの実装

### DIFF
--- a/lib/auth/data/data_resources/login_data_source.dart
+++ b/lib/auth/data/data_resources/login_data_source.dart
@@ -8,11 +8,15 @@ import 'package:yjg/auth/data/models/user.dart';
 import 'package:yjg/auth/presentation/viewmodels/privilege_viewmodel.dart';
 import 'package:yjg/auth/presentation/viewmodels/user_viewmodel.dart';
 import 'package:yjg/shared/constants/api_url.dart';
+import 'package:yjg/shared/service/interceptor.dart';
 
 class LoginDataSource {
   static final Dio dio = Dio();
   static final storage = FlutterSecureStorage(); // 토큰 담는 곳
 
+  LoginDataSource() {
+      dio.interceptors.add(DioInterceptor(dio)); // 수정된 생성자를 사용
+  }
   // 스토리지 모듈
   Future<void> _saveToStorage(Map<String, String> data) async {
     for (var key in data.keys) {
@@ -47,6 +51,9 @@ class LoginDataSource {
         'name': userGenerated.user!.name!,
         'student_num': userGenerated.user!.studentId!,
       });
+
+      debugPrint('토큰 저장: ${userGenerated.accessToken}');
+      debugPrint('리프레시 토큰 저장: ${userGenerated.refreshToken}');
 
       return response.data;
     } catch (e) {

--- a/lib/auth/data/data_resources/user_data_source.dart
+++ b/lib/auth/data/data_resources/user_data_source.dart
@@ -1,34 +1,30 @@
-import 'dart:convert';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:yjg/shared/constants/api_url.dart';
+import 'package:yjg/shared/service/interceptor.dart';
 
 class UserDataSource {
   // 유저 정보 호출
-  
-  // approve 변경
-  Future<http.Response> patchApproveAPI(String token) async {
-    final body = jsonEncode(<String, bool>{"approve": true});
-    debugPrint('내가 보내는 값: $body');
-    debugPrint('토큰: $token');
-    final uri = Uri.parse('$apiURL/api/user/approve');
-    final response = await http.patch(
-        uri,
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer $token',
-        },
-        body: jsonEncode(<String, dynamic>{"approve": true}));
+  static final Dio dio = Dio();
 
-    if (response.statusCode == 200) {
-      // 성공적으로 데이터를 받아옴
+  UserDataSource() {
+    dio.interceptors.add(DioInterceptor(dio));
+  }
+
+  // approve 변경
+  Future<Response> patchApproveAPI() async {
+    final data = {"approve": true};
+
+    final url = '$apiURL/api/user/approve';
+
+    try {
+      final response = await dio.patch(url, data: data);
+
       debugPrint('patchApproveAPI 호출 성공');
-      debugPrint(response.body);
       return response;
-    } else {
-      // 오류 처리
-      debugPrint(response.body);
-      throw Exception('업데이트 실패: ${response.statusCode} ${response.body}');
+    } catch (e) {
+      debugPrint('통신 결과: $e');
+      throw Exception('approve 변경에 실패했습니다.');
     }
   }
 }

--- a/lib/auth/domain/entities/user.dart
+++ b/lib/auth/domain/entities/user.dart
@@ -44,7 +44,7 @@ class User extends ChangeNotifier {
     if (name != null) this.name = name;
     if (phoneNumber != null) this.phoneNumber = phoneNumber;
     if (studentId != null) this.studentId = studentId;
- 
+
     notifyListeners(); // User 객체가 변경되었음을 알림
   }
 
@@ -84,6 +84,15 @@ class User extends ChangeNotifier {
     if (email != null) this.email = email;
     if (displayName != null) this.displayName = displayName;
     if (idToken != null) this.idToken = idToken;
+
+    notifyListeners(); // User 객체가 변경되었음을 알림
+  }
+
+  // 비밀번호 재설정 폼 업데이트
+  void resetPasswordFormUpdate({
+    String? newPassword,
+  }) {
+    if (newPassword != null) this.newPassword = newPassword;
 
     notifyListeners(); // User 객체가 변경되었음을 알림
   }

--- a/lib/auth/domain/usecases/detail_usecase.dart
+++ b/lib/auth/domain/usecases/detail_usecase.dart
@@ -37,7 +37,7 @@ class DetailUseCase {
     // 추가 정보 입력 API 호출
     try {
       final dataSource = RegisterDataSource(); // DataSource 인스턴스 생성
-      final response = await dataSource.patchAdditionalInfoAPI(ref, token);
+      final response = await dataSource.patchAdditionalInfoAPI(ref);
 
       if (response.statusCode == 200) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/auth/domain/usecases/reset_password_new_usecase.dart
+++ b/lib/auth/domain/usecases/reset_password_new_usecase.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yjg/auth/data/data_resources/reset_password_data_source.dart';
+import 'package:yjg/auth/presentation/viewmodels/user_viewmodel.dart';
+import 'package:yjg/shared/theme/palette.dart';
+
+class ResetPasswordNewUseCase {
+  final WidgetRef ref;
+
+  ResetPasswordNewUseCase({required this.ref});
+
+  Future<void> execute({
+    required String newPassword,
+    required BuildContext context,
+  }) async {
+    // User 상태 업데이트를 위해 userProvider를 통해 User 인스턴스에 접근
+    ref.read(userProvider.notifier).resetPasswordFormUpdate(
+          newPassword: newPassword,
+        );
+
+    // 비밀번호 업데이트
+    try {
+      ResetPasswordDataSource dataSource = ResetPasswordDataSource();
+      await dataSource.patchNewPasswordAPI(ref);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('비밀번호가 변경되었습니다. 로그인 해 주세요.'),
+          backgroundColor: Palette.mainColor,
+        ),
+      );
+      // 성공 시 로그인 페이지로 이동
+      Navigator.pushNamed(context, '/login_student');
+    } catch (e) {
+      // 회원가입 실패 시 에러 메시지 표시
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('비밀번호 변경에 실패했습니다. 다시 시도해 주세요.'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+}

--- a/lib/auth/domain/usecases/reset_password_verify_code_usecase.dart
+++ b/lib/auth/domain/usecases/reset_password_verify_code_usecase.dart
@@ -12,7 +12,6 @@ class ResetPasswordVerifyCodeUseCase {
   Future<void> execute({
     required String verifyCode,
     required BuildContext context,
-
   }) async {
     ref.read(verifyCodeProvider.notifier).setVerifyCode(verifyCode);
 
@@ -22,16 +21,15 @@ class ResetPasswordVerifyCodeUseCase {
       await dataSource.postResetPasswordMailVerifyAPI(ref);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('인증에 성공했습니다. 비밀번호를 재설정해 주세요.'),
-          backgroundColor: Palette.mainColor
-        ),
+            content: Text('인증에 성공했습니다. 비밀번호를 재설정해 주세요.'),
+            backgroundColor: Palette.mainColor),
       );
-
+      Navigator.pushNamed(context, '/new_password');
     } catch (e) {
       // 회원가입 실패 시 에러 메시지 표시
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('유저 정보가 존재하지 않습니다. 다시 한 번 확인해 주세요.'),
+          content: Text('인증번호가 올바르지 않습니다. 다시 한 번 확인해 주세요.'),
           backgroundColor: Colors.red,
         ),
       );

--- a/lib/auth/domain/usecases/update_usecase.dart
+++ b/lib/auth/domain/usecases/update_usecase.dart
@@ -44,7 +44,7 @@ class UpdateUserInfoUseCase {
     // 업데이트 API 호출
     try {
       final dataSource = RegisterDataSource(); // DataSource 인스턴스 생성
-      final response = await dataSource.patchAdditionalInfoAPI(ref, token);
+      final response = await dataSource.patchAdditionalInfoAPI(ref);
 
       if (response.statusCode == 200) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/auth/presentation/pages/new_password_update.dart
+++ b/lib/auth/presentation/pages/new_password_update.dart
@@ -1,0 +1,130 @@
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:yjg/auth/domain/usecases/reset_password_new_usecase.dart";
+import "package:yjg/auth/presentation/widgets/auth_text_form_field.dart";
+import "package:yjg/shared/theme/palette.dart";
+
+class newPasswordUpdate extends ConsumerWidget {
+  final _formKey = GlobalKey<FormState>();
+
+  TextEditingController passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              SizedBox(
+                height: 80.0,
+              ),
+              Icon(
+                Icons.error_outline_rounded,
+                size: 50.0,
+                color: Palette.mainColor,
+              ),
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0),
+                child: const Text(
+                  '새로운 비밀번호를 입력해 주세요.',
+                  style: TextStyle(fontSize: 18.0, color: Palette.textColor),
+                ),
+              ),
+
+              // 폼 시작
+              Form(
+                key: _formKey,
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 25, vertical: 16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 14),
+                        child: AuthTextFormField(
+                          controller: passwordController,
+                          labelText: "비밀번호",
+                          validatorText: "새로운 비밀번호를 입력해 주세요.",
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 22.0),
+                        child: SizedBox(
+                          width: double.infinity, // 버튼을 부모의 가로 길이만큼 확장
+
+                          // 버튼
+                          child: ElevatedButton(
+                            onPressed: () async {
+                              if (_formKey.currentState!.validate()) {
+                                try {
+                                  final resetPasswordNewUsecase =
+                                      ResetPasswordNewUseCase(ref: ref);
+
+                                  await resetPasswordNewUsecase.execute(
+                                    newPassword: passwordController.text,
+                                    context: context,
+                                  );
+                                } catch (e) {
+                                  debugPrint('비밀번호 업데이트 실패: $e');
+                                }
+                              } else {
+                                // Form이 유효하지 않은 경우, 사용자에게 알림
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text(
+                                        '입력되지 않은 필드가 있습니다. 다시 한 번 확인해 주세요.'),
+                                    backgroundColor: Palette.mainColor,
+                                  ),
+                                );
+                              }
+                            },
+                            style: ButtonStyle(
+                              backgroundColor:
+                                  MaterialStateProperty.resolveWith<Color>(
+                                      (states) {
+                                if (states.contains(MaterialState.pressed)) {
+                                  return Palette.mainColor.withOpacity(0.8);
+                                }
+                                return Palette.mainColor;
+                              }),
+                              foregroundColor:
+                                  MaterialStateProperty.resolveWith<Color>(
+                                      (states) {
+                                if (states.contains(MaterialState.pressed)) {
+                                  return Colors.white.withOpacity(0.8);
+                                }
+                                return Colors.white;
+                              }),
+                              shape: MaterialStateProperty.all<
+                                  RoundedRectangleBorder>(
+                                RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(10),
+                                  side: BorderSide(color: Palette.mainColor),
+                                ),
+                              ),
+                              fixedSize: MaterialStateProperty.all<Size>(
+                                  Size(100, 40)),
+                            ),
+                            child: const Text(
+                              '비밀번호 변경',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/auth/presentation/widgets/international_admin_login_form.dart
+++ b/lib/auth/presentation/widgets/international_admin_login_form.dart
@@ -50,24 +50,23 @@ class _InternationalAdminLoginForm extends State<InternationalAdminLoginForm> {
               children: [
                 AutoLoginCheckBox(),
                 Spacer(),
-                if (widget.studentOrAdmin == true)
-                  Padding(
-                    padding: const EdgeInsets.only(),
-                    child: TextButton(
-                      onPressed: () {
-                        Navigator.pushNamed(context, '/reset_password');
-                      },
-                      child: Text(
-                        "비밀번호 찾기",
-                        style: TextStyle(
-                          color: Palette.mainColor,
-                          fontSize: fontSize * 0.035,
-                          letterSpacing: -0.5,
-                          fontWeight: FontWeight.w600,
-                        ),
+                Padding(
+                  padding: const EdgeInsets.only(),
+                  child: TextButton(
+                    onPressed: () {
+                      Navigator.pushNamed(context, '/reset_password');
+                    },
+                    child: Text(
+                      "비밀번호 찾기",
+                      style: TextStyle(
+                        color: Palette.mainColor,
+                        fontSize: fontSize * 0.035,
+                        letterSpacing: -0.5,
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
                   ),
+                ),
               ],
             ),
             Padding(

--- a/lib/dashboard/data/data_sources/urgent_data_source.dart
+++ b/lib/dashboard/data/data_sources/urgent_data_source.dart
@@ -1,36 +1,26 @@
-import 'dart:convert';
-
-import 'package:flutter/material.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:yjg/shared/constants/api_url.dart';
+import 'package:yjg/shared/service/interceptor.dart';
 
 class UrgentDataSource {
-  String getApiUrl() {
-    // 상수 파일에서 가져온 apiURL 사용
-    return apiURL;
-  }
-
+  static final Dio dio = Dio(); // Dio 인스턴스 생성
   static final storage = FlutterSecureStorage(); // 토큰 담는 곳
 
+  UrgentDataSource() {
+    dio.interceptors.add(DioInterceptor(dio));
+  }
+
 // * 최근 공지사항
-  Future<http.Response> getUrgentApi() async {
-    final token = await storage.read(key: 'auth_token');
+  Future<Response> getUrgentApi() async {
     String url = '$apiURL/api/notice/recent/urgent';
 
-    Uri uri = Uri.parse(url);
+    try {
+      final response = await dio.get(url);
 
-    final response = await http.get(
-      uri,
-      headers: <String, String>{
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer $token',
-      },
-    );
-
-    if (response.statusCode == 200) {
       return response;
-    } else {
+    } catch (e) {
       throw Exception('최근 공지 데이터 가져오기에 실패하였습니다.');
     }
   }

--- a/lib/dashboard/presentaion/viewmodels/urgent_viewmodel.dart
+++ b/lib/dashboard/presentaion/viewmodels/urgent_viewmodel.dart
@@ -1,8 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/dashboard/data/data_sources/urgent_data_source.dart';
-import 'dart:convert';
-
 import 'package:yjg/dashboard/data/models/urgent.dart';
 
 
@@ -10,10 +7,10 @@ import 'package:yjg/dashboard/data/models/urgent.dart';
 Future<Notice> fetchUrgentNotice() async {
   final response = await UrgentDataSource().getUrgentApi();
   if (response.statusCode == 200) {
-    final data = jsonDecode(utf8.decode(response.bodyBytes));
+    final data = response.data;
     return Notice.fromJson(data);
   } else {
-    throw Exception('Failed to load notice');
+    throw Exception('공지사항을 불러오지 못했습니다.');
   }
 }
 

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yjg/auth/presentation/pages/new_password_update.dart';
 import 'package:yjg/auth/presentation/pages/student_login.dart';
 import 'package:yjg/dashboard/presentaion/pages/dashboard_main.dart';
 import 'package:yjg/administration/presentaion/pages/admin_main.dart';
@@ -48,6 +49,7 @@ class AppRoutes {
     '/update_user': (context) => UpdateUser(),
     '/reset_password': (context) => ResetPassword(),
     '/mail_verification_code': (context) => MailVerficationCode(),
+    '/new_password': (context) => newPasswordUpdate(),
 
     // 식수 관련
     '/restaurant_main': (context) => RestaurantMain(),


### PR DESCRIPTION
## 📣 연관된 이슈
> #190 #177 

## 📝 작업 내용
> 한국어
1. Auth 관련 일부 API 로직에 dio 인터셉터로 로직 교체하였습니다.
2. 비밀번호 재설정 로직을 구현하였습니다.
3. 최근 1건 공지 위젯을 수정하였습니다
4. dio 인터셉터의 401 Unauthorized 에러 처리 부분을 개선하였습니다.

> 日本語
1. 認証関連の一部APIロジックをdioインターセプターで置き換えました。
2. パスワードリセットロジックを実装しました。
3. 最近1件のお知らせウィジェットを修正しました。
4. dioインターセプターの401 Unauthorizedエラー処理を改善しました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
