### PR TITLE
Fix: リフレッシュトークンのJSON返却キー値の修正

### DIFF
--- a/lib/auth/data/data_resources/login_data_source.dart
+++ b/lib/auth/data/data_resources/login_data_source.dart
@@ -123,7 +123,7 @@ class LoginDataSource {
 
     if (response.statusCode == 200) {
       final responseData = json.decode(response.body);
-      final accessToken = responseData['refresh_token'];
+      final accessToken = responseData['access_token'];
       // 토큰 교체
       storage.write(key: 'auth_token', value: accessToken);
       debugPrint('리프레시 토큰 교환 완료, 액세스 토큰 교체: $accessToken');

--- a/lib/auth/data/data_resources/reset_password_data_source.dart
+++ b/lib/auth/data/data_resources/reset_password_data_source.dart
@@ -18,7 +18,7 @@ class ResetPasswordDataSource {
   // * 이메일 전송
   Future<Response> postResetPasswordAPI(WidgetRef ref) async {
     final loginState = ref.read(userProvider.notifier);
-    String url = '$apiURL/reset-password';
+    String url = '$apiURL/api/reset-password';
     final data = {
       'email': loginState.email,
       'name': loginState.name,
@@ -71,7 +71,7 @@ class ResetPasswordDataSource {
   // * 비밀번호 재설정
   Future<Response> patchNewPasswordAPI(WidgetRef ref) async {
     final loginState = ref.read(userProvider.notifier);
-    String url = '$apiURL/api/user/password';
+    String url = '$apiURL/api/reset-password';
     final data = {
       'password': loginState.newPassword,
     };

--- a/lib/salon/presentaion/viewmodels/category_viewmodel.dart
+++ b/lib/salon/presentaion/viewmodels/category_viewmodel.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/salon/data/data_sources/price_data_source.dart';
 import 'package:yjg/salon/data/models/category.dart';


### PR DESCRIPTION
## 📣 연관된 이슈
> X

## 📝 작업 내용
> 한국어
1. 토큰 교체 로직 내 JSON 키값을 변경하였습니다.
2. 비밀번호 초기화 API의 엔드포인트를 수정하였습니다.

> 日本語
1. トークン交換ロジック内のJSONキー値を変更しました。
2. パスワードリセットAPIのエンドポイントを修正しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
