### PR TITLE
Refactor: BottomNavigationBarのHomeボタン修正

### DIFF
--- a/lib/as(admin)/presentation/pages/as_detail.dart
+++ b/lib/as(admin)/presentation/pages/as_detail.dart
@@ -277,6 +277,7 @@ class _AsDetailState extends ConsumerState<AsDetail> {
                       style: const TextStyle(
                           fontSize: 18, fontWeight: FontWeight.w600),
                     ),
+                    SizedBox(height: 10.0,),
                     asDetail['afterService']['after_service_images'].length == 0
                         ? Padding(
                             padding: const EdgeInsets.all(10.0),

--- a/lib/auth/data/data_resources/logout_data_source.dart
+++ b/lib/auth/data/data_resources/logout_data_source.dart
@@ -15,15 +15,7 @@ class LogoutDataSource {
 
   // 로그아웃
   Future<void> postLogoutAPI(WidgetRef ref) async {
-    bool? isAdmin = await storage.read(key: 'isAdmin') == 'ture'
-        ? true
-        : false; // false: Student, true: Admin
-    debugPrint('isAdmin: $isAdmin');
-    final String url;
-    isAdmin == true
-        ? url = '$apiURL/api/admin/logout'
-        : url = '$apiURL/api/user/logout';
-
+    final String url = '$apiURL/api/logout';
     try {
       await dio.post(url);
 

--- a/lib/shared/widgets/bottom_navigation_bar.dart
+++ b/lib/shared/widgets/bottom_navigation_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yjg/shared/service/auth_service.dart';
 import 'package:yjg/shared/theme/palette.dart';
 
 class CustomBottomNavigationBar extends StatelessWidget {
@@ -19,11 +20,14 @@ class CustomBottomNavigationBar extends StatelessWidget {
       ],
       unselectedItemColor: Colors.grey,
       selectedItemColor: Palette.mainColor,
-      onTap: (int index) {
+      onTap: (int index) async {
         switch (index) {
           case 0:
-            // 현재 열려있는 창 다 닫고 홈(첫번째 페이지)으로 이동
-            Navigator.of(context).popUntil((route) => route.isFirst);
+            final initialRoute = await AuthService().getInitialRoute();
+            Navigator.of(context).pushNamedAndRemoveUntil(
+              initialRoute!,
+              (route) => false,
+            );
             break;
           case 1:
             Navigator.of(context).pushNamed('/setting');


### PR DESCRIPTION
## 📣 연관된 이슈
> X

## 📝 작업 내용
> 한국어
1. BottomNavigationBar의 홈 버튼을 눌렀을 경우, AuthService 클래스의 getInitialRoute()를 통하여 기본 라우터를 불러올 수 있도록 수정하였습니다.
2. 로그아웃 API 엔드포인트 변경에 따른 로직 수정이 이루어졌습니다.

> 日本語
1. BottomNavigationBarのホームボタンを押した場合、AuthServiceクラスのgetInitialRoute()を通じてデフォルトルーターを呼び出せるように修正しました。
2. ログアウトAPIエンドポイントの変更に伴うロジックの修正が行われました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
