### PR TITLE
Feat: トークン中央管理シングルトンクラスの実装

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,7 +45,6 @@ class MyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-
     return MaterialApp(
       //외박 신청 달력 언어 설정
       localizationsDelegates: [

--- a/lib/shared/service/interceptor.dart
+++ b/lib/shared/service/interceptor.dart
@@ -1,12 +1,17 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:yjg/auth/data/data_resources/login_data_source.dart';
+import 'package:yjg/shared/service/token_refresh_manager.dart';
 
 final FlutterSecureStorage storage = FlutterSecureStorage();
 
 // 토큰 로컬 스토리지에서 가져옴
 Future<String?> getToken() async {
   return await storage.read(key: 'auth_token');
+}
+
+// 리프레시 토큰 로컬 스토리지에서 가져옴
+Future<String?> getRefreshToken() async {
+  return await storage.read(key: 'refresh_token');
 }
 
 // 요청, 응답, 에러에 대한 인터셉터
@@ -29,8 +34,14 @@ class DioInterceptor extends Interceptor {
       options.headers["Content-Type"] = "application/json";
     }
 
-    // 인증 토큰이 필요한 경우 헤더에 추가
-    if (options.extra["noAuth"] != true) {
+    // 리프레시 토큰 사용이 필요한 경우
+    if (options.extra["useRefreshToken"] == true) {
+      final refreshToken = await getRefreshToken();
+      if (refreshToken != null) {
+        options.headers["Authorization"] = "Bearer $refreshToken";
+      }
+    } else if (options.extra["noAuth"] != true) {
+      // 일반적인 액세스 토큰 사용 경우
       final token = await getToken();
       if (token != null) {
         options.headers["Authorization"] = "Bearer $token";
@@ -48,26 +59,32 @@ class DioInterceptor extends Interceptor {
   }
 
   @override
+  // 에러 발생 시 실행되는 메서드
   void onError(DioException err, ErrorInterceptorHandler handler) async {
-
-    // 401 Unauthorized 에러가 발생했을 경우, noAuth 옵션이 false인 경우만 처리
+    // 401 Unauthorized 에러 처리
     if (err.response?.statusCode == 401 &&
         err.requestOptions.extra["noAuth"] != true) {
-      // 새 토큰을 얻기 위해 getRefreshTokenAPI 호출
-      await LoginDataSource().getRefreshTokenAPI();
-      // 갱신된 토큰을 사용하여 요청 재시도
-      final token = await getToken(); // 갱신된 토큰 가져오기
-      handler.resolve(await _retry(err.requestOptions, token));
+      try {
+        // TokenRefreshManager를 사용하여 토큰 리프레시 로직 실행
+        await TokenRefreshManager()
+            .refreshTokenIfNeeded(err.requestOptions, dio);
+        // 토큰이 갱신된 후 요청 재시도
+        final response = await _retry(err.requestOptions);
+        handler.resolve(response);
+      } catch (e) {
+        // 재시도에 실패하거나 리프레시 토큰 자체가 실패한 경우
+        super.onError(err, handler);
+      }
     } else {
-      // noAuth가 true이거나 다른 에러인 경우 기존 에러 처리 로직을 그대로 진행
-      handler.next(err);
+      super.onError(err, handler);
     }
   }
 
   // 새 토큰을 사용하여 요청 재시도
-  Future<Response<dynamic>> _retry(
-      RequestOptions requestOptions, String? token) async {
+  Future<Response<dynamic>> _retry(RequestOptions requestOptions) async {
     const maxRetryCount = 3; // 최대 재시도 횟수
+    final token = await getToken(); // 새 토큰 가져오기
+
     requestOptions.headers["Authorization"] = "Bearer $token";
 
     // 재시도 횟수를 가져와서 1 증가

--- a/lib/shared/service/token_refresh_manager.dart
+++ b/lib/shared/service/token_refresh_manager.dart
@@ -1,0 +1,63 @@
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:yjg/auth/data/data_resources/login_data_source.dart';
+import 'package:yjg/shared/service/interceptor.dart';
+
+// 토큰 갱신 로직을 중앙에서 관리하는 싱글톤 클래스, 동시에 여러 API 호출이 발생할 때 
+// 중복된 토큰 갱신 요청을 방지하기 위해 사용
+
+class TokenRefreshManager {
+  // TokenRefreshManager의 싱글톤 인스턴스를 저장
+  static final TokenRefreshManager _instance = TokenRefreshManager._internal();
+  
+  // 토큰 갱신 요청 진행 여부
+  bool _isRefreshing = false;
+  
+  // 토큰 갱신 요청이 진행 중일 때 대기 상태에 있는 모든 요청을 저장
+  // 각 요소는 새 토큰으로 요청을 재시도할 수 있는 함수
+  final List<Function(String)> _waitingRequests = [];
+
+  // factory 생성자를 통해 클래스의 싱글톤 인스턴스에 접근 가능
+  factory TokenRefreshManager() {
+    return _instance;
+  }
+
+  // 싱글톤 인스턴스 초기화
+  TokenRefreshManager._internal();
+
+  // 토큰 갱신이 이미 되고 있지 않은 경우에만 토큰 갱신 로직을 실행
+  // 토큰 갱신이 필요한 경우 모든 대기 중인 요청 -> 새 토큰이 발급될 때까지 대기 상태가 됨
+  Future<void> refreshTokenIfNeeded(RequestOptions requestOptions, Dio dio) async {
+    if (!_isRefreshing) {
+      _isRefreshing = true;
+      try {
+        // 액세스 토큰 업데이트 API
+        String newToken = await LoginDataSource().getRefreshTokenAPI();
+        await storage.write(key: 'auth_token', value: newToken);
+        // 대기 중인 모든 요청에 새 토큰을 적용, 처리
+        _processWaitingRequests(newToken);
+      } finally {
+        _isRefreshing = false;
+      }
+    } else {
+      // 토큰 갱신 요청이 이미 진행 중이면 요청을 대기 리스트에 추가
+      final completer = Completer<void>();
+      _waitingRequests.add((token) {
+        requestOptions.headers["Authorization"] = "Bearer $token";
+        completer.complete();
+      });
+      return completer.future;
+    }
+  }
+
+  // 새 토큰이 발급된 후 대기 중인 모든 요청을 처리
+  // 대기 중인 요청에 토근을 적용하고, 대기 리스트를 비움
+  void _processWaitingRequests(String newToken) {
+    for (var request in _waitingRequests) {
+      request(newToken);
+    }
+    _waitingRequests.clear();
+  }
+}


### PR DESCRIPTION
## 📣 연관된 이슈
> X

## 📝 작업 내용
> 한국어
1. 여러 API가 동시 호출될 때 액세스 토큰 요청 API가 여러 번 호출되는 버그를 발견하여, 토큰을 효율적으로 관리하기 위해 싱글톤 클래스를 구현했습니다. (새 토큰이 획득될 때까지 대기 중인 요청을 큐에 넣음으로써 중복 토큰 갱신 작업을 방지, 토큰 갱신을 기다리는 요청을 보관하기 위해 Completer 활용)
2. 관리자 로그인 API와 액세스 토큰 요청 API가 인터셉터 적용이 되지 않은 것을 확인하여 코드 리팩토링이 진행되었습니다.

> 日本語
1. 複数のAPIが同時に呼び出される際に、アクセストークンの要求APIが複数回呼び出されるバグを発見し、トークンを効率的に管理するためにシングルトンクラスを実装しました。 (新しいトークンが取得されるまで待機中の要求をキューに入れることで、重複したトークン更新作業を防ぎ、トークン更新を待機している要求を保持するためにCompleterを活用)
2. 管理者ログインAPIとアクセストークン要求APIにインターセプターが適用されていないことが確認されたため、コードのリファクタリングが行われました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
