### PR TITLE
Feat: お知らせ詳細ページのルーターを分離及びお知らせウィジェットと接続

### DIFF
--- a/lib/administration/data/data_sources/notice_data_source.dart
+++ b/lib/administration/data/data_sources/notice_data_source.dart
@@ -23,4 +23,16 @@ class NoticeDataSource {
       throw Exception('공지사항 로드에 실패했습니다.');
     }
   }
+
+  // * 특정 공지사항 불러오는 GET API
+  Future<Response> getNotice(int noticeId) async {
+    String url = '$apiURL/api/notice/$noticeId';
+    try {
+      final response = await dio.get(url);
+      return response;
+    } catch (e) {
+      debugPrint('Error: $e');
+      throw Exception('공지사항 로드에 실패했습니다.');
+    }
+  }
 }

--- a/lib/administration/presentaion/pages/notice.dart
+++ b/lib/administration/presentaion/pages/notice.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:yjg/administration/data/data_sources/notice_data_source.dart';
-import 'package:yjg/administration/presentaion/pages/notice_detail_page.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
 import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
@@ -146,12 +145,7 @@ class _NoticeState extends State<Notice> {
 
     return GestureDetector(
       onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => NoticeDetailPage(notice: notice),
-          ),
-        );
+        Navigator.pushNamed(context, '/notice_detail', arguments: notice['id']);
       },
       child: Center(
         child: Container(

--- a/lib/auth/data/data_resources/login_data_source.dart
+++ b/lib/auth/data/data_resources/login_data_source.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -37,19 +36,13 @@ class LoginDataSource {
           data: data, options: Options(extra: {"noAuth": true}));
       Usergenerated userGenerated = Usergenerated.fromJson(response.data);
 
-      // 사용자 기본 정보 업데이트
-      ref.read(userProvider.notifier).additionalInfoFormUpdate(
-            name: userGenerated.user!.name!,
-            phoneNumber: userGenerated.user!.phoneNumber!,
-            studentId: userGenerated.user!.studentId!,
-          );
-
       // 스토리지에 토큰과 사용자 정보 저장
       await _saveToStorage({
         'auth_token': userGenerated.accessToken!,
         'refresh_token': userGenerated.refreshToken!,
         'name': userGenerated.user!.name!,
         'student_num': userGenerated.user!.studentId!,
+        'phone_num' : userGenerated.user!.phoneNumber!,
       });
 
       debugPrint('토큰 저장: ${userGenerated.accessToken}');
@@ -63,7 +56,7 @@ class LoginDataSource {
   }
 
 // * 관리자 로그인
-  Future<Response> postAdminLoginAPI(WidgetRef ref) async {
+  Future<Map<String, dynamic>> postAdminLoginAPI(WidgetRef ref) async {
     final loginState = ref.read(userProvider.notifier);
     final url = '$apiURL/api/admin/login';
     final data = {
@@ -75,7 +68,7 @@ class LoginDataSource {
       final response = await dio.post(url,
           data: data, options: Options(extra: {"noAuth": true}));
 
-      final result = Usergenerated.fromJson(jsonDecode(response.data));
+      final result = Usergenerated.fromJson(response.data);
       String? token = result.accessToken; // 토큰값 추출
       String? refreshToken = result.refreshToken; // 리프레시 토큰값 추출
 
@@ -93,7 +86,7 @@ class LoginDataSource {
               .read(adminPrivilegesProvider.notifier)
               .updatePrivileges(result.user!);
         }
-        return response;
+        return response.data;
       } else {
         throw Exception('토큰이 없습니다.');
       }

--- a/lib/bus/presentaion/pages/bus_main.dart
+++ b/lib/bus/presentaion/pages/bus_main.dart
@@ -26,7 +26,8 @@ class _BusMainState extends ConsumerState<BusMain> {
       bottomNavigationBar: const CustomBottomNavigationBar(),
       appBar: const BaseAppBar(title: '버스'),
       drawer: BaseDrawer(),
-      body: SingleChildScrollView( // SingleChildScrollView 추가하여 스크롤 가능하도록 수정
+      body: SingleChildScrollView(
+        // SingleChildScrollView 추가하여 스크롤 가능하도록 수정
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
@@ -95,18 +96,30 @@ class _BusMainState extends ConsumerState<BusMain> {
                     itemCount: notices.length,
                     itemBuilder: (context, index) {
                       final notice = notices[index];
-                      return Padding(
-                        padding: const EdgeInsets.only(right: 20.0),
-                        child: NoticeBox(
-                          title: notice.title ?? '제목 없음',
-                          content: notice.content ?? '내용 없음',
+                      return GestureDetector(
+                        onTap: () {
+                          Navigator.pushNamed(
+                            context,
+                            '/notice_detail',
+                            arguments: notice.id, // 공지사항의 ID를 인자로 전달
+                          );
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.only(right: 20.0),
+                          child: NoticeBox(
+                            title: notice.title ?? '제목 없음',
+                            content: notice.content ?? '내용 없음',
+                          ),
                         ),
                       );
                     },
                   ),
                 );
               },
-              loading: () => const Center(child: CircularProgressIndicator(color: Palette.stateColor4,)),
+              loading: () => const Center(
+                  child: CircularProgressIndicator(
+                color: Palette.stateColor4,
+              )),
               error: (error, _) => Center(child: Text('Error: $error')),
             ),
           ],

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yjg/administration/presentaion/pages/notice_detail_page.dart';
 import 'package:yjg/auth/presentation/pages/new_password_update.dart';
 import 'package:yjg/auth/presentation/pages/student_login.dart';
 import 'package:yjg/dashboard/presentaion/pages/dashboard_main.dart';
@@ -78,6 +79,10 @@ class AppRoutes {
     //행정 관련
     '/admin_main': (context) => AdminMain(),
     '/notice': (context) => Notice(),
+    '/notice_detail': (context) {
+      final noticeId = ModalRoute.of(context)!.settings.arguments as int;
+      return NoticeDetailPage(noticeId: noticeId);
+    },
     '/as_page': (context) => AsPage(),
     '/as_application': (context) => AsApplication(),
     '/sleepover': (context) => Sleepover(),

--- a/lib/salon/presentaion/pages/admin/admin_salon_main.dart
+++ b/lib/salon/presentaion/pages/admin/admin_salon_main.dart
@@ -124,23 +124,34 @@ class _AdminSalonMainState extends ConsumerState<AdminSalonMain> {
                     ),
                   ),
                   noticesAsyncValue.when(
-                    data: (notices) => SizedBox(
-                      height: 140.0,
-                      child: ListView.builder(
-                        scrollDirection: Axis.horizontal,
-                        itemCount: notices.length,
-                        itemBuilder: (context, index) {
-                          final notice = notices[index];
-                          return Padding(
-                            padding: const EdgeInsets.only(right: 20.0),
-                            child: NoticeBox(
-                              title: notice.title ?? '제목 없음',
-                              content: notice.content ?? '내용 없음',
-                            ),
-                          );
-                        },
-                      ),
-                    ),
+                    data: (notices) {
+                      return SizedBox(
+                        height: 140.0,
+                        child: ListView.builder(
+                          scrollDirection: Axis.horizontal,
+                          itemCount: notices.length,
+                          itemBuilder: (context, index) {
+                            final notice = notices[index];
+                            return GestureDetector(
+                              onTap: () {
+                                Navigator.pushNamed(
+                                  context,
+                                  '/notice_detail',
+                                  arguments: notice.id, // 공지사항의 ID를 인자로 전달
+                                );
+                              },
+                              child: Padding(
+                                padding: const EdgeInsets.only(right: 20.0),
+                                child: NoticeBox(
+                                  title: notice.title ?? '제목 없음',
+                                  content: notice.content ?? '내용 없음',
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      );
+                    },
                     loading: () => const Center(
                         child: CircularProgressIndicator(
                             color: Palette.stateColor4)),

--- a/lib/salon/presentaion/pages/salon_main.dart
+++ b/lib/salon/presentaion/pages/salon_main.dart
@@ -121,7 +121,9 @@ class _SalonMainState extends ConsumerState<SalonMain> {
                                 route: '/salon_price_list'),
                           ],
                         ),
-                        SizedBox(height: 10.0,),
+                        SizedBox(
+                          height: 10.0,
+                        ),
                         // 공지사항
                         Container(
                           margin: const EdgeInsets.symmetric(
@@ -142,11 +144,22 @@ class _SalonMainState extends ConsumerState<SalonMain> {
                                 itemCount: notices.length,
                                 itemBuilder: (context, index) {
                                   final notice = notices[index];
-                                  return Padding(
-                                    padding: const EdgeInsets.only(right: 20.0),
-                                    child: NoticeBox(
-                                      title: notice.title ?? '제목 없음',
-                                      content: notice.content ?? '내용 없음',
+                                  return GestureDetector(
+                                    onTap: () {
+                                      Navigator.pushNamed(
+                                        context,
+                                        '/notice_detail',
+                                        arguments:
+                                            notice.id, // 공지사항의 ID를 인자로 전달
+                                      );
+                                    },
+                                    child: Padding(
+                                      padding:
+                                          const EdgeInsets.only(right: 20.0),
+                                      child: NoticeBox(
+                                        title: notice.title ?? '제목 없음',
+                                        content: notice.content ?? '내용 없음',
+                                      ),
                                     ),
                                   );
                                 },

--- a/lib/shared/service/navigate_and_remove_until.dart
+++ b/lib/shared/service/navigate_and_remove_until.dart
@@ -1,0 +1,7 @@
+ import 'package:flutter/material.dart';
+
+/// 네비게이터를 사용하여 라우트를 이동하고, 이전 라우트를 제거
+  void navigateAndRemoveUntil(BuildContext context, String routeName) {
+    Navigator.pushNamedAndRemoveUntil(
+        context, routeName, (Route<dynamic> route) => false);
+  }


### PR DESCRIPTION
## 📣 연관된 이슈
> X

## 📝 작업 내용
> 한국어
1. 공지사항 상세보기 페이지 라우터 분리 및 공지사항 위젯과 연결하였습니다.
2. 관리자 로그인 로직 내 jsoonDecode 키워드를 제거하였습니다.

> 일본어
1. お知らせ詳細ページのルーターを分離し、お知らせウィジェットと接続しました。
2. 管理者ログインのjsonDecodeキーワードを削除しました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
