### PR TITLE
Feat: ログイン時にFCMトークンをサーバーに送信するロジックを追加

### DIFF
--- a/lib/auth/data/data_resources/google_login_data_source.dart
+++ b/lib/auth/data/data_resources/google_login_data_source.dart
@@ -7,6 +7,7 @@ import 'package:yjg/auth/data/models/user.dart';
 import 'package:yjg/auth/domain/usecases/domain_validation_usecase.dart';
 import 'package:yjg/auth/presentation/viewmodels/user_viewmodel.dart';
 import 'package:yjg/main.dart';
+import 'package:yjg/setting/data/data_sources/fcm_token_datasource.dart';
 import 'package:yjg/shared/constants/api_url.dart';
 import 'package:yjg/shared/service/interceptor.dart';
 import 'package:yjg/shared/service/save_to_storage.dart';
@@ -19,20 +20,21 @@ class GoogleLoginDataSource {
   );
 
   static final Dio dio = Dio();
-  static final _storage = FlutterSecureStorage();
-
+  static final storage = FlutterSecureStorage();
   GoogleLoginDataSource() {
     dio.interceptors.add(DioInterceptor(dio));
   }
 
-  // 구글로 로그인하는 함수
+  // * 구글 로그인 함수
   Future<void> signInWithGoogle(WidgetRef ref, BuildContext context) async {
     try {
-      await _googleSignIn.signIn();
-      final GoogleSignInAccount? account = _googleSignIn.currentUser;
-      final domainValidationUseCase = DomainValidationUseCase();
+      await _googleSignIn.signIn(); // 구글 로그인
+      final GoogleSignInAccount? account =
+          _googleSignIn.currentUser; // 로그인한 계정 정보
 
       // 이메일 도메인이 학교 이메일인지 확인
+      final domainValidationUseCase = DomainValidationUseCase();
+
       if (account != null) {
         if (!domainValidationUseCase(account.email)) {
           _showSnackBar(context, '학교 이메일(@g.yju.ac.kr)이 아닐 경우 로그인을 할 수 없습니다.');
@@ -40,16 +42,17 @@ class GoogleLoginDataSource {
           return;
         }
 
-        // 구글 로그인 후 토큰을 교환
+        // 구글 로그인 정보
         GoogleSignInAuthentication googleAuth = await account.authentication;
-        printLongString(googleAuth.idToken ?? 'idToken is null');
 
+        // 사용자 정보 업데이트
         ref.read(userProvider.notifier).updateWithGoogleSignIn(
               email: account.email,
               displayName: account.displayName,
               idToken: googleAuth.idToken,
             );
 
+        // 토큰 교환 API 호출
         await _postGoogleLoginAPI(ref);
       }
     } catch (error) {
@@ -57,57 +60,70 @@ class GoogleLoginDataSource {
     }
   }
 
-  void printLongString(String text, {int chunkSize = 1024}) {
-    RegExp exp = RegExp('.{1,$chunkSize}');
-    Iterable<Match> matches = exp.allMatches(text);
-
-    for (Match match in matches) {
-      debugPrint(match.group(0));
-    }
+  // * 구글 로그아웃
+  Future<void> logoutWithGoogle() async {
+    _googleSignIn.signOut();
+    debugPrint('구글 로그아웃 완료');
   }
 
-  // 구글로 로그인 후 토큰을 교환하는 함수
+  // * 구글 로그인 후 자체 토큰 교환 API
   Future<void> _postGoogleLoginAPI(WidgetRef ref) async {
-    final loginState = ref.read(userProvider.notifier);
-    final deviceInfo = await _storage.read(key: 'deviceType');
+    final loginState =
+        ref.read(userProvider.notifier); // 로그인한 유저 정보(토큰 교환을 위한 정보)
+    final deviceInfo = await storage.read(
+        key: 'deviceType'); // 디바이스 정보(ios와 android 클라이언트 id가 다르므로 디바이스 정보로 식별)
     String url = '$apiURL/api/user/google-login';
+
     final data = {
       'email': loginState.email,
       'displayName': loginState.displayName,
       'id_token': loginState.idToken,
       'os_type': deviceInfo ?? 'unknown',
     };
-
+    
     try {
       final response = await dio.post(url,
-          data: data, options: Options(extra: {"noAuth": true}));
+          data: data,
+          options: Options(
+              extra: {"noAuth": true})); // noAuth : AccessToken을 사용하지 않는 API
 
-      final result = Usergenerated.fromJson(response.data);
-      debugPrint('통신 결과: ${response.data} ${response.statusCode}');
+      final result = Usergenerated.fromJson(response.data); // 사용자 정보 파싱
 
-      String? token = result.accessToken;
-      int? approved = result.user?.approved;
+      String? token = result.accessToken; // 토큰
+      int? approved = result.user?.approved; // 사용자 승인 여부
 
       if (token != null) {
         // 스토리지에 토큰과 사용자 정보 저장
-        await saveToStorage(
-            {'auth_token': token, 'refresh_token': result.refreshToken!});
+        await saveToStorage({
+          'auth_token': token,
+          'refresh_token': result.refreshToken!,
+          'login_type': 'google'
+        });
       } else {
-        debugPrint('토큰이 없습니다.');
         throw Exception('토큰이 없습니다.');
       }
 
+      // 만약 승인이 되지 않았다면 사용자 정보 입력 페이지로 이동
       if (approved == 0) {
+        // approve 저장
+        await saveToStorage({
+          'approve': '0',
+        });
+
         navigatorKey.currentState!.pushNamed('/registration_detail');
       } else if (approved == 1) {
-        // 사용자 기본 정보 업데이트
+        // 승인이 되었다면 사용자 기본 정보 업데이트
         await saveToStorage({
           'name': result.user!.name!,
           'student_num': result.user!.studentId!,
           'phone_num': result.user!.phoneNumber!,
-          'auto_login' : "true",
+          'auto_login': "true", // 구글 로그인 시 자동 로그인 고정
           'userType': 'student',
         });
+
+        // FCM 토큰 업데이트
+        FcmTokenDataSource().patchFcmTokenAPI();
+
         // 로그인 성공 시 메인 대시보드로 이동
         navigatorKey.currentState!.pushReplacementNamed('/dashboard_main');
       }
@@ -127,7 +143,4 @@ class GoogleLoginDataSource {
       ),
     );
   }
-
-  // 로그아웃하는 함수
-  static Future<void> logout() => _googleSignIn.signOut();
 }

--- a/lib/auth/data/data_resources/login_data_source.dart
+++ b/lib/auth/data/data_resources/login_data_source.dart
@@ -5,6 +5,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:yjg/auth/data/models/user.dart';
 import 'package:yjg/auth/presentation/viewmodels/privilege_viewmodel.dart';
 import 'package:yjg/auth/presentation/viewmodels/user_viewmodel.dart';
+import 'package:yjg/setting/data/data_sources/fcm_token_datasource.dart';
 import 'package:yjg/shared/constants/api_url.dart';
 import 'package:yjg/shared/service/interceptor.dart';
 import 'package:yjg/shared/service/save_to_storage.dart';
@@ -17,7 +18,7 @@ class LoginDataSource {
     dio.interceptors.add(DioInterceptor(dio)); // 수정된 생성자를 사용
   }
 
-  // 외국인 유학생 로그인
+  //* 외국인 유학생 로그인
   Future<Map<String, dynamic>> postStudentLoginAPI(WidgetRef ref) async {
     final loginState = ref.read(userProvider.notifier);
     final url = '$apiURL/api/user/login';
@@ -42,6 +43,9 @@ class LoginDataSource {
 
       debugPrint('토큰 저장: ${userGenerated.accessToken}');
       debugPrint('리프레시 토큰 저장: ${userGenerated.refreshToken}');
+
+      // FCM 토큰 업데이트
+      FcmTokenDataSource().patchFcmTokenAPI();
 
       return response.data;
     } catch (e) {
@@ -85,6 +89,10 @@ class LoginDataSource {
               .read(adminPrivilegesProvider.notifier)
               .updatePrivileges(result.user!);
         }
+
+        // FCM 토큰 업데이트
+        FcmTokenDataSource().patchFcmTokenAPI();
+
         return response.data;
       } else {
         throw Exception('토큰이 없습니다.');

--- a/lib/auth/data/data_resources/logout_data_source.dart
+++ b/lib/auth/data/data_resources/logout_data_source.dart
@@ -3,6 +3,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:yjg/auth/data/data_resources/google_login_data_source.dart';
 import 'package:yjg/shared/constants/api_url.dart';
 import 'package:yjg/shared/service/interceptor.dart';
 
@@ -14,11 +15,17 @@ class LogoutDataSource {
     dio.interceptors.add(DioInterceptor(dio));
   }
 
-  // 로그아웃
+  // * 로그아웃
   Future<void> postLogoutAPI(WidgetRef ref) async {
     final String url = '$apiURL/api/logout';
     try {
       await dio.post(url);
+
+      // 만약 구글 로그인을 통해 로그인했을 경우 구글 로그아웃
+      final loginType = await storage.read(key: 'login_type');
+      if (loginType == 'google') {
+        GoogleLoginDataSource().logoutWithGoogle();
+      }
 
       // 스토리지에 저장된 모든 정보를 삭제함
       await storage.deleteAll();

--- a/lib/firebase_api.dart
+++ b/lib/firebase_api.dart
@@ -2,11 +2,13 @@ import 'dart:convert';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:yjg/shared/service/notification_service.dart';
 
 class FirebaseApi {
   // 메시지 수신을 위한 FirebaseMessaging 인스턴스 생성
   final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
+  final storage = FlutterSecureStorage(); // FCM 토큰 저장
 
   // 알림 기능 초기화
   Future<void> initNotifications() async {
@@ -24,8 +26,9 @@ class FirebaseApi {
     FirebaseMessaging.onBackgroundMessage(_firebaseMessageHandler);
 
     // Firebase에서 제공하는 토큰 가져오기(디바이스 식별용)
-    final FCMToken = await _firebaseMessaging.getToken();
-    debugPrint('Token: $FCMToken');
+    String? fcmToken = await _firebaseMessaging.getToken();
+    await storage.write(key: 'fcm_token', value: fcmToken);
+    debugPrint('FCM 토큰: $fcmToken');
   }
 
   // 포그라운드, 백그라운드 메시지 처리 핸들러

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,8 +4,6 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:yjg/firebase_api.dart';
 import 'firebase_options.dart';
-// import 'package:shared_preferences/shared_preferences.dart';
-
 import 'package:yjg/routes/app_routes.dart';
 import 'package:yjg/shared/service/auth_service.dart';
 import 'package:yjg/shared/service/device_info.dart';

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -36,7 +36,7 @@ import 'package:yjg/salon/presentaion/pages/salon_booking_step_two.dart';
 import 'package:yjg/salon/presentaion/pages/salon_main.dart';
 import 'package:yjg/salon/presentaion/pages/salon_my_book.dart';
 import 'package:yjg/salon/presentaion/pages/salon_price_list.dart';
-import 'package:yjg/setting/setting_page.dart';
+import 'package:yjg/setting/presentation/pages/setting_page.dart';
 
 class AppRoutes {
   static final Map<String, WidgetBuilder> routes = {

--- a/lib/setting/data/data_sources/fcm_token_datasource.dart
+++ b/lib/setting/data/data_sources/fcm_token_datasource.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:yjg/shared/constants/api_url.dart';
+import 'package:yjg/shared/service/interceptor.dart';
+
+class FcmTokenDataSource {
+  static final Dio dio = Dio();
+  static final storage = FlutterSecureStorage(); // 토큰 담는 곳
+
+  FcmTokenDataSource() {
+    dio.interceptors.add(DioInterceptor(dio));
+  }
+
+  // * FCM TOKEN 업데이트
+  // 로그인 시 FCM 토큰을 업데이트, 자동 로그인 시에도 업데이트
+  Future<Response> patchFcmTokenAPI() async {
+    String url = '$apiURL/api/fcm-token';
+    String fcmToken = storage.read(key: 'fcm_token').toString();
+
+    final data = {
+      'fcm_token': fcmToken,
+    };
+
+    try {
+      final response = await dio.patch(url, data: data);
+      debugPrint('FCM Token 업데이트 성공: $response');
+      return response;
+    } on DioException catch (e) {
+      throw Exception('FCM Token 업데이트 오류 발생: $e');
+    } catch (e) {
+      throw Exception('FCM Token 업데이트에 실패하였습니다.');
+    }
+  }
+}

--- a/lib/setting/presentation/pages/setting_page.dart
+++ b/lib/setting/presentation/pages/setting_page.dart
@@ -146,26 +146,25 @@ class _SettingPageState extends ConsumerState<SettingPage> {
                   );
 
                   if (confirmDelete == true) {
-                    UserDataSource().deleteUserAccountAPI();
-                  }
+                    try {
+                      UserDataSource().deleteUserAccountAPI();
 
-                  try {
-                    await storage.deleteAll();
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('회원탈퇴에 성공하였습니다. 로그아웃됩니다.'),
-                        backgroundColor: Palette.mainColor,
-                      ),
-                    );
-                    Navigator.pushNamedAndRemoveUntil(context, '/login_student',
-                        (Route<dynamic> route) => false);
-                  } catch (e) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('회원탈퇴 실패. 다시 시도해 주세요. 에러: $e'),
-                        backgroundColor: Colors.red,
-                      ),
-                    );
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('회원탈퇴에 성공하였습니다. 로그아웃됩니다.'),
+                          backgroundColor: Palette.mainColor,
+                        ),
+                      );
+                      Navigator.pushNamedAndRemoveUntil(context,
+                          '/login_student', (Route<dynamic> route) => false);
+                    } catch (e) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('회원탈퇴 실패. 다시 시도해 주세요. 에러: $e'),
+                          backgroundColor: Colors.red,
+                        ),
+                      );
+                    }
                   }
                 }),
               ),

--- a/lib/shared/service/auth_service.dart
+++ b/lib/shared/service/auth_service.dart
@@ -3,9 +3,15 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:yjg/auth/data/data_resources/login_data_source.dart';
 import 'package:yjg/routes/app_routes.dart';
+import 'package:yjg/setting/data/data_sources/fcm_token_datasource.dart';
 
 class AuthService {
   final FlutterSecureStorage storage = FlutterSecureStorage();
+
+  // fcm token getter
+  Future<String?> getFcmToken() async {
+    return await storage.read(key: 'fcm_token');
+  }
 
   Future<String?> getInitialRoute() async {
     final token = await storage.read(key: 'auth_token');
@@ -40,6 +46,9 @@ class AuthService {
     if (autoLoginStr == 'true' && (JwtDecoder.isExpired(token))) {
       // 리프레시 토큰으로 액세스 토큰 갱신
       await LoginDataSource().getRefreshTokenAPI();
+
+      // FCM 토큰 업데이트
+      await FcmTokenDataSource().patchFcmTokenAPI();
 
       // 갱신된 액세스 토큰으로 초기 라우터 설정
       final newToken = await storage.read(key: 'auth_token');


### PR DESCRIPTION
## 📣 연관된 이슈
> X

## 📝 작업 내용
> 한국어
1. 로그인 시 FCM 토큰을 서버로 전송하는 로직을 추가하였습니다. (일반 유저 로그인, 구글 로그인, 관리자 로그인 / 자동로그인인 경우에는, 어플 접속 시 FCM 재전송되도록 함)
2. 설정 페이지 파일을 이동하였습니다.

> 日本語
1. ログイン時にFCMトークンをサーバーへ送信するロジックを追加しました。（一般ユーザーログイン、Googleログイン、管理者ログイン/自動ログインの場合、アプリにアクセスするたびにFCMが再送信されるように設定）
2. 設定ページのファイルを移動しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
