### PR TITLE
Refactor: プッシュ通知（FCM）の設定一部変更

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,5 +89,6 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.google.firebase:firebase-messaging-ktx'
     implementation 'androidx.multidex:multidex:2.0.1'
+    implementation platform('com.google.firebase:firebase-bom:31.0.1')
     // coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.0'
+    ext.kotlin_version = '1.9.24'
     repositories {
         google()
         mavenCentral()

--- a/lib/auth/data/data_resources/google_login_data_source.dart
+++ b/lib/auth/data/data_resources/google_login_data_source.dart
@@ -120,6 +120,7 @@ class GoogleLoginDataSource {
           'phone_number': result.user!.phoneNumber!,
           'auto_login': "true", // 구글 로그인 시 자동 로그인 고정
           'userType': 'student',
+          'push': result.user!.pushEnabled.toString(),
         });
 
         // FCM 토큰 업데이트

--- a/lib/auth/data/data_resources/login_data_source.dart
+++ b/lib/auth/data/data_resources/login_data_source.dart
@@ -30,19 +30,20 @@ class LoginDataSource {
     try {
       final response = await dio.post(url,
           data: data, options: Options(extra: {"noAuth": true}));
-      Usergenerated userGenerated = Usergenerated.fromJson(response.data);
+      final result = Usergenerated.fromJson(response.data);
 
       // 스토리지에 토큰과 사용자 정보 저장
       await saveToStorage({
-        'auth_token': userGenerated.accessToken!,
-        'refresh_token': userGenerated.refreshToken!,
-        'name': userGenerated.user!.name!,
-        'student_id': userGenerated.user!.studentId!,
-        'phone_number': userGenerated.user!.phoneNumber!,
+        'auth_token': result.accessToken!,
+        'refresh_token': result.refreshToken!,
+        'name': result.user!.name!,
+        'student_id': result.user!.studentId!,
+        'phone_number': result.user!.phoneNumber!,
+        'push': result.user!.pushEnabled.toString(),
       });
 
-      debugPrint('토큰 저장: ${userGenerated.accessToken}');
-      debugPrint('리프레시 토큰 저장: ${userGenerated.refreshToken}');
+      debugPrint('토큰 저장: ${result.accessToken}');
+      debugPrint('리프레시 토큰 저장: ${result.refreshToken}');
 
       // FCM 토큰 업데이트
       FcmTokenDataSource().patchFcmTokenAPI();
@@ -78,6 +79,7 @@ class LoginDataSource {
           'refresh_token': result.refreshToken!,
           'name': result.user!.name!,
           'phone_num': result.user!.phoneNumber!,
+          'push': result.user!.pushEnabled.toString(),
         });
 
         debugPrint('토큰 저장: $token');

--- a/lib/auth/data/models/user.dart
+++ b/lib/auth/data/models/user.dart
@@ -29,6 +29,9 @@ class User {
   String? phoneNumber;
   String? email;
   int? approved;
+  int? admin;
+  String? fcmToken;
+  int? pushEnabled;
   String? createdAt;
   String? updatedAt;
   List<Privileges>? privileges;
@@ -39,6 +42,9 @@ class User {
       this.name,
       this.phoneNumber,
       this.email,
+      this.admin,
+      this.fcmToken,
+      this.pushEnabled,
       this.approved,
       this.createdAt,
       this.updatedAt,
@@ -51,6 +57,9 @@ class User {
     phoneNumber = json['phone_number'];
     email = json['email'];
     approved = json['approved'];
+    admin = json['admin'];
+    fcmToken = json['fcm_token'];
+    pushEnabled = json['push_enabled'];
     createdAt = json['created_at'];
     updatedAt = json['updated_at'];
     if (json['privileges'] != null) {
@@ -69,6 +78,9 @@ class User {
     data['phone_number'] = phoneNumber;
     data['email'] = email;
     data['approved'] = approved;
+    data['admin'] = admin;
+    data['fcm_token'] = fcmToken;
+    data['push_enabled'] = pushEnabled;
     data['created_at'] = createdAt;
     data['updated_at'] = updatedAt;
     if (privileges != null) {

--- a/lib/auth/presentation/pages/update_user.dart
+++ b/lib/auth/presentation/pages/update_user.dart
@@ -156,10 +156,12 @@ class _UpdateUser extends ConsumerState<UpdateUser> {
                             // 폰 번호 대조
                             if (defaultPhoneNumber !=
                                 phoneNumberController.text) {
-                              change['phone_number'] = phoneNumberController.text;
+                              String phoneNumber = phoneNumberController.text
+                                  .replaceAll(RegExp(r'[^\d]'), '');
+
+                              change['phone_number'] = phoneNumber;
                               await storage.write(
-                                  key: 'phone_number',
-                                  value: phoneNumberController.text);
+                                  key: 'phone_number', value: phoneNumber);
                             }
                             // 학번 대조
                             if (defaultStudentId != studentIdController.text) {
@@ -171,7 +173,8 @@ class _UpdateUser extends ConsumerState<UpdateUser> {
 
                             // 그 외 비밀번호
                             if (passwordController.text.isNotEmpty) {
-                              change['current_password'] = passwordController.text;
+                              change['current_password'] =
+                                  passwordController.text;
                             }
                             if (newPasswordController.text.isNotEmpty) {
                               change['new_password'] =

--- a/lib/firebase_api.dart
+++ b/lib/firebase_api.dart
@@ -20,29 +20,36 @@ class FirebaseApi {
     );
 
     // 포그라운드 메시지 처리
-    FirebaseMessaging.onMessage.listen(_firebaseMessageHandler);
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+      _handleMessage(message);
+    });
 
     // 백그라운드 메시지 처리
-    FirebaseMessaging.onBackgroundMessage(_firebaseMessageHandler);
+    //     FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
+    //       _handleMessage(message);
+    //     });
 
     // Firebase에서 제공하는 토큰 가져오기(디바이스 식별용)
-    String? fcmToken = await _firebaseMessaging.getToken();
-    await storage.write(key: 'fcm_token', value: fcmToken);
-    debugPrint('FCM 토큰: $fcmToken');
+    updateToken();
   }
 
-  // 포그라운드, 백그라운드 메시지 처리 핸들러
-  static Future<void> _firebaseMessageHandler(RemoteMessage message) async {
-    // 로그인 했을 경우에만 옴(로그아웃 시에는 토큰이 삭제되기 때문)
+  // 토큰 갱신 및 저장 메서드
+  Future<void> updateToken() async {
+    String? fcmToken = await _firebaseMessaging.getToken();
+    await storage.write(key: 'fcm_token', value: fcmToken);
+    debugPrint('FCM 토큰 갱신: $fcmToken');
+  }
+
+  // 포그라운드 핸들러
+  void _handleMessage(RemoteMessage message) {
     if (message.notification != null) {
       final title = message.notification!.title ?? "No Title";
       final body = message.notification!.body ?? "No Body";
-      final payload = jsonEncode(message.data); // 알림과 함께 전달할 추가 데이터
+      final payload = jsonEncode(message.data);
 
       debugPrint('onMessage: $title / $body / $payload');
 
-      await NotificationService()
-          .showNotification(title, body, payload: payload);
+      NotificationService().showNotification(title, body, payload: payload);
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 // 네비게이터 키
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
-void main() async {
+Future<void> main() async {
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   await Firebase.initializeApp(

--- a/lib/salon/presentaion/widgets/filter_service_list.dart
+++ b/lib/salon/presentaion/widgets/filter_service_list.dart
@@ -14,7 +14,7 @@ class FilterServiceList extends ConsumerWidget {
     final userSelection = ref.watch(userSelectionProvider);
     final selectedGender = userSelection.selectedGender; // 성별
     final selectedCategoryId = userSelection.selectedCategoryId;
-    String uniqueKey = "${selectedGender}_${selectedCategoryId}";
+    String uniqueKey = "${selectedGender}_$selectedCategoryId";
 
     final servicesAsyncValue = ref.watch(servicesProvider(uniqueKey));
 

--- a/lib/setting/data/data_sources/fcm_token_datasource.dart
+++ b/lib/setting/data/data_sources/fcm_token_datasource.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:yjg/firebase_api.dart';
 import 'package:yjg/shared/constants/api_url.dart';
 import 'package:yjg/shared/service/interceptor.dart';
 
@@ -16,11 +17,15 @@ class FcmTokenDataSource {
   // 로그인 시 FCM 토큰을 업데이트, 자동 로그인 시에도 업데이트
   Future<Response> patchFcmTokenAPI() async {
     String url = '$apiURL/api/fcm-token';
-    String fcmToken = storage.read(key: 'fcm_token').toString();
+    FirebaseApi firebaseApi = FirebaseApi();
+    await firebaseApi.updateToken();
+    String? fcmToken = await storage.read(key: 'fcm_token');
 
     final data = {
       'fcm_token': fcmToken,
     };
+
+    debugPrint('보내는 FCM Token: $fcmToken');
 
     try {
       final response = await dio.patch(url, data: data);

--- a/lib/setting/presentation/pages/setting_page.dart
+++ b/lib/setting/presentation/pages/setting_page.dart
@@ -12,8 +12,8 @@ import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/bottom_navigation_bar.dart';
 
 class SettingPage extends ConsumerStatefulWidget {
-  const SettingPage({Key? key}) : super(key: key);
-
+  SettingPage({Key? key}) : super(key: key);
+  bool notifications = false;
   @override
   _SettingPageState createState() => _SettingPageState();
 }
@@ -22,17 +22,25 @@ class _SettingPageState extends ConsumerState<SettingPage> {
   static final storage = FlutterSecureStorage();
   static String? userType;
   final pushNotificationUseCase = PushNotificationUseCase(FcmTokenDataSource());
-  bool notifications = true; // 알림 수신 여부 기본값
 
   // storage에서 isAdmin 값을 읽어와서 상태를 업데이트하는 메소드
   Future<void> getUserInfo() async {
     userType = await storage.read(key: 'userType');
   }
 
+  Future<void> getPushNotification() async {
+    final storage = FlutterSecureStorage();
+    bool push = await storage.read(key: 'push') == '0' ? false : true;
+    setState(() {
+      widget.notifications = push;
+    });
+  }
+
   @override
   void initState() {
     super.initState();
     getUserInfo();
+    getPushNotification();
   }
 
   @override
@@ -71,13 +79,13 @@ class _SettingPageState extends ConsumerState<SettingPage> {
                   '알림',
                   style: TextStyle(letterSpacing: -0.5, fontSize: 15.0),
                 ),
-                initialValue: notifications,
+                initialValue: widget.notifications,
                 onToggle: (value) {
                   setState(() {
-                    notifications = !notifications;
+                    widget.notifications = !widget.notifications;
 
                     // 푸쉬 알림 허용 여부 업데이트
-                    pushNotificationUseCase.call(notifications);
+                    pushNotificationUseCase.call(widget.notifications);
                   });
                 },
                 leading: Icon(Icons.notifications),

--- a/lib/shared/service/auth_service.dart
+++ b/lib/shared/service/auth_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:yjg/auth/data/data_resources/login_data_source.dart';
+import 'package:yjg/firebase_api.dart';
 import 'package:yjg/routes/app_routes.dart';
 import 'package:yjg/setting/data/data_sources/fcm_token_datasource.dart';
 
@@ -18,6 +19,8 @@ class AuthService {
     final autoLoginStr = await storage.read(key: 'auto_login') ?? 'false';
     final refreshToken = await storage.read(key: 'refresh_token');
     final userType = await storage.read(key: 'userType');
+    FirebaseApi firebaseApi = FirebaseApi();
+    await firebaseApi.updateToken();
 
     debugPrint('액세스 토큰: $token');
     debugPrint('리프레시 토큰: $refreshToken');

--- a/lib/shared/service/notification_service.dart
+++ b/lib/shared/service/notification_service.dart
@@ -43,11 +43,11 @@ class NotificationService {
   void handleNotificationClick(String? payload) {
     if (payload != null && navigatorKey.currentState != null) {
       final data = jsonDecode(payload);
-      final id = data['id'];
+      final id = int.parse(data['id']);
 
       switch (data['page']) {
         case 'as': // 관리자, 학생 AS(댓글 등록, AS 접수, AS 처리)
-          navigatorKey.currentState!.pushNamed('/notice_detail', arguments: id);
+          navigatorKey.currentState!.pushNamed('/as_detail', arguments: id);
           break;
         case 'notice': // 긴급 공지사항
           navigatorKey.currentState!.pushNamed('/notice_detail', arguments: id);

--- a/lib/shared/widgets/as_card.dart
+++ b/lib/shared/widgets/as_card.dart
@@ -39,7 +39,6 @@ class _AsCardState extends State<AsCard> {
             ),
           ),
           onPressed: () {
-            print('Navigating to details with id: ${widget.id}');
             Navigator.pushNamed(
               context,
               '/as_detail',

--- a/lib/shared/widgets/base_drawer.dart
+++ b/lib/shared/widgets/base_drawer.dart
@@ -23,7 +23,7 @@ class _BaseDrawerState extends ConsumerState<BaseDrawer> {
   Future<void> getUserInfo() async {
     final storage = FlutterSecureStorage();
     String? name = await storage.read(key: 'name');
-    String? studentNum = await storage.read(key: 'student_num');
+    String? studentNum = await storage.read(key: 'student_id');
     setState(() {
       widget.name = name;
       widget.studenNum = studentNum;

--- a/lib/shared/widgets/bottom_navigation_bar.dart
+++ b/lib/shared/widgets/bottom_navigation_bar.dart
@@ -24,10 +24,12 @@ class CustomBottomNavigationBar extends StatelessWidget {
         switch (index) {
           case 0:
             final initialRoute = await AuthService().getInitialRoute();
-            Navigator.of(context).pushNamedAndRemoveUntil(
-              initialRoute!,
-              (route) => false,
-            );
+            if (context.mounted) {
+              Navigator.of(context).pushNamedAndRemoveUntil(
+                initialRoute!,
+                (route) => false,
+              );
+            }
             break;
           case 1:
             Navigator.of(context).pushNamed('/setting');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -653,30 +653,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.0"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -705,26 +681,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -745,10 +721,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   path_provider:
     dependency: transitive
     description:
@@ -1106,14 +1082,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
-      url: "https://pub.dev"
-    source: hosted
-    version: "13.0.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## 📣 연관된 이슈
> X

## 📝 작업 내용
> 한국어
1. 푸쉬 알림(FCM) 로직을 일부 수정하였습니다.
2. 로그인 시 `fcm_token`, `push_enabled` 추가 반환에 따라 User 모델을 수정하였습니다.
3. 정보 수정 페이지 내 전화번호 전송 시 하이픈을 제거하는 로직이 누락되어 추가하였습니다.
4. 그 외 불필요한 코드 및 로직 개선이 일부 이루어졌습니다.

> 日本語
1. プッシュ通知（FCM）ロジックを一部修正しました。
2. ログイン時に`fcm_token`と`push_enabled`の追加返却に合わせて、ユーザーモデルを修正しました。
3. 情報修正ページ内で電話番号送信時にハイフンを削除するロジックが欠けていたため、追加しました。
4. その他、不要なコードとロジックの改善が一部行われました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
