### PR TITLE
Fix: メインダッシュボードのボタンナビゲーターにメディアクエリを適用

### DIFF
--- a/lib/administration/presentaion/pages/meeting_room_main.dart
+++ b/lib/administration/presentaion/pages/meeting_room_main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:yjg/administration/data/data_sources/meeting_room_data_source.dart';
+import 'package:yjg/shared/theme/palette.dart';
 import 'package:yjg/shared/widgets/base_appbar.dart';
 import 'package:yjg/shared/widgets/base_drawer.dart';
 import 'package:yjg/shared/widgets/blue_main_rounded_box.dart';
@@ -198,7 +199,7 @@ class _MeetingRoomMainState extends State<MeetingRoomMain> {
       builder: (BuildContext context) {
         return AlertDialog(
           title: Text(statusText,
-              style: TextStyle(color: textColor)), // 여기서 색상과 내용을 적용
+              style: TextStyle(color: textColor, fontSize: 18, fontWeight: FontWeight.bold)), // 여기서 색상과 내용을 적용
           content: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.center,
@@ -207,7 +208,7 @@ class _MeetingRoomMainState extends State<MeetingRoomMain> {
               SizedBox(height: 20,),
               Container(
                 width: 350,
-                padding: EdgeInsets.only(bottom: 20),
+                padding: EdgeInsets.only(bottom: 5),
                 decoration: BoxDecoration(
                   border: Border(
                     bottom: BorderSide(
@@ -224,9 +225,11 @@ class _MeetingRoomMainState extends State<MeetingRoomMain> {
                       " ${reservation['reservation_date']}",
                       style: TextStyle(fontSize: 15),
                     ),
-                    SizedBox(width: 20,),
+                    SizedBox(width: 10,),
                     Text(
                         "$startTime ~ ${reservation['reservation_e_time'].split(':')[0]}:59",style: TextStyle(fontSize: 15),),
+                 
+                    
                   ],
                 ),
               ),
@@ -234,13 +237,13 @@ class _MeetingRoomMainState extends State<MeetingRoomMain> {
           ),
           actions: <Widget>[
             TextButton(
-              child: Text("확인"),
+              child: Text("확인", style: TextStyle(color: Palette.textColor)),
               onPressed: () {
                 Navigator.of(context).pop();
               },
             ),
             TextButton(
-              child: Text("삭제"),
+              child: Text("삭제", style: TextStyle(color: Palette.stateColor3)),
               onPressed: () {
                 // 삭제 확인 대화상자 표시
                 showDeleteConfirmationDialog(context, reservation['id']);
@@ -258,17 +261,17 @@ class _MeetingRoomMainState extends State<MeetingRoomMain> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: Text("예약 삭제 확인"),
+          title: Text("예약 삭제 확인", style: TextStyle(color: Palette.textColor, fontSize: 16, fontWeight: FontWeight.bold)),
           content: Text("이 예약을 삭제하시겠습니까?"),
           actions: <Widget>[
             TextButton(
-              child: Text("취소"),
+              child: Text("취소", style: TextStyle(color: Palette.textColor)),
               onPressed: () {
                 Navigator.of(context).pop();
               },
             ),
             TextButton(
-              child: Text("확인"),
+              child: Text("확인", style: TextStyle(color: Palette.stateColor3)),
               onPressed: () {
                 // 예약 삭제 API 호출
                 deleteReservation(context, reservationId);

--- a/lib/administration/presentaion/pages/sleepover_application.dart
+++ b/lib/administration/presentaion/pages/sleepover_application.dart
@@ -29,11 +29,18 @@ class _SleepoverApplicationState extends State<SleepoverApplication> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: Text(title),
+          title: Text(title,
+              style: TextStyle(
+                  color: Palette.textColor,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold)),
           content: Text(content),
           actions: <Widget>[
             TextButton(
-              child: Text('확인'),
+              child: Text(
+                '확인',
+                style: TextStyle(color: Palette.stateColor3),
+              ),
               onPressed: () {
                 Navigator.of(context).pop(); // 다이얼로그 닫기
               },
@@ -286,7 +293,6 @@ class _SleepoverApplicationState extends State<SleepoverApplication> {
     }
 
     String type = _startDate == _endDate ? 'go' : 'sleep';
-    Uri apiUrl = Uri.parse('$apiURL/api/absence');
 
     try {
       final response = await _sleepoverDataSource.submitApplication(
@@ -307,11 +313,13 @@ class _SleepoverApplicationState extends State<SleepoverApplication> {
     } on DioException catch (e) {
       // 409 예외 처리
       if (e.response?.statusCode == 409) {
-        _showDialog('예약 중복', '해당 날짜에 이미 예약이 존재합니다.');
+        _showDialog('예약 중복', '이미 신청된 날짜입니다.');
+      } else {
+        _showDialog('실패', '예기치 못한 오류가 발생했습니다.'); // 예외 메시지를 사용
       }
     } catch (e) {
       // 예외 처리
-      _showDialog('에러', '오류가 발생했습니다: $e');
+      _showDialog('에러', '예기치 못한 오류가 발생했습니다.');
     }
   }
 }

--- a/lib/as(admin)/data/data_sources/as_comment_data_source.dart
+++ b/lib/as(admin)/data/data_sources/as_comment_data_source.dart
@@ -35,7 +35,12 @@ class AsCommentDataSource {
       final response = await dio.post(url, data: {'comment': comment});
       debugPrint('댓글 등록 결과: ${response.statusCode}, ${response.data}');
       return response;
-    } catch (e) {
+    } on DioException catch (e) {
+      debugPrint('댓글 작성 실패: ${e.response!.statusCode}, ${e.response!.data}');
+      throw Exception('댓글 작성에 실패했습니다. : $e');
+    } 
+    
+    catch (e) {
       throw Exception('댓글 작성에 실패했습니다.');
     }
   }

--- a/lib/as(admin)/presentation/pages/as_detail.dart
+++ b/lib/as(admin)/presentation/pages/as_detail.dart
@@ -104,13 +104,19 @@ class _AsDetailState extends ConsumerState<AsDetail> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: Text('삭제 확인'),
+          title: Text('삭제 확인',
+              style: TextStyle(
+                  color: Palette.textColor,
+                  fontSize: 16.0,
+                  fontWeight: FontWeight.w600)),
           content: Text('정말 삭제하시겠습니까?'),
           actions: <Widget>[
             TextButton(
               onPressed: () =>
                   Navigator.of(context).pop(false), // '아니오' 선택 시 false 반환
-              child: Text('아니오'),
+              child: Text('취소',
+                  style: TextStyle(
+                      color: Palette.stateColor4, fontWeight: FontWeight.w600)),
             ),
             TextButton(
               onPressed: () {
@@ -118,7 +124,9 @@ class _AsDetailState extends ConsumerState<AsDetail> {
                 Navigator.pop(context);
                 Navigator.popAndPushNamed(context, '/as_page');
               },
-              child: Text('예'),
+              child: Text('삭제',
+                  style: TextStyle(
+                      color: Palette.stateColor3, fontWeight: FontWeight.w600)),
             ),
           ],
         );
@@ -257,17 +265,20 @@ class _AsDetailState extends ConsumerState<AsDetail> {
                                 ),
                                 SizedBox(height: 15),
                                 ElevatedButton(
-                                  style: ButtonStyle(
-                                    backgroundColor: MaterialStatePropertyAll(Palette.mainColor),
-                                  ),
-                                  onPressed: () {
-                                    updateAsDetail(
-                                        asId,
-                                        _contentController.text,
-                                        _editedVisitDate ?? "");
-                                  },
-                                  child: Icon(Icons.task_alt,color: Colors.white,)
-                                ),
+                                    style: ButtonStyle(
+                                      backgroundColor: MaterialStatePropertyAll(
+                                          Palette.mainColor),
+                                    ),
+                                    onPressed: () {
+                                      updateAsDetail(
+                                          asId,
+                                          _contentController.text,
+                                          _editedVisitDate ?? "");
+                                    },
+                                    child: Icon(
+                                      Icons.task_alt,
+                                      color: Colors.white,
+                                    )),
                               ],
                             )
                           : Text(asDetail['afterService']['content']),
@@ -277,7 +288,9 @@ class _AsDetailState extends ConsumerState<AsDetail> {
                       style: const TextStyle(
                           fontSize: 18, fontWeight: FontWeight.w600),
                     ),
-                    SizedBox(height: 10.0,),
+                    SizedBox(
+                      height: 10.0,
+                    ),
                     asDetail['afterService']['after_service_images'].length == 0
                         ? Padding(
                             padding: const EdgeInsets.all(10.0),
@@ -291,7 +304,8 @@ class _AsDetailState extends ConsumerState<AsDetail> {
                           TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
                     ),
                     AsCommentBox(
-                        serviceId: asId,),
+                      serviceId: asId,
+                    ),
                     SizedBox(height: 60.0),
                   ],
                 ),

--- a/lib/dashboard/presentaion/pages/dashboard_main.dart
+++ b/lib/dashboard/presentaion/pages/dashboard_main.dart
@@ -36,32 +36,34 @@ class DashboardMain extends ConsumerWidget {
                     right: 0,
                     child: Padding(
                       padding: EdgeInsets.symmetric(horizontal: 20.0),
-                      child: Wrap(
-                        alignment: WrapAlignment.center,
-                        spacing: 30,
-                        runSpacing: 30,
-                        children: <Widget>[
-                          MoveButton(
-                              icon: Icons.directions_bus,
-                              text1: '버스',
-                              text2: '버스 시간표, 버스 QR',
-                              route: '/bus_main'),
-                          MoveButton(
-                              icon: Icons.restaurant,
-                              text1: '식수',
-                              text2: '식수 QR, 식수신청 등',
-                              route: '/restaurant_main'),
-                          MoveButton(
-                              icon: Icons.cut,
-                              text1: '미용실',
-                              text2: '미용실 예약, 가격표',
-                              route: '/salon_main'),
-                          MoveButton(
-                              icon: Icons.support_agent,
-                              text1: '행정',
-                              text2: '공지사항, AS 요청 등',
-                              route: '/admin_main'),
-                        ],
+                      child: SizedBox(
+                        child: Wrap(
+                          alignment: WrapAlignment.center,
+                          spacing: MediaQuery.of(context).size.width / 15,
+                          runSpacing: 30,
+                          children: <Widget>[
+                            MoveButton(
+                                icon: Icons.directions_bus,
+                                text1: '버스',
+                                text2: '버스 시간표, 버스 QR',
+                                route: '/bus_main'),
+                            MoveButton(
+                                icon: Icons.restaurant,
+                                text1: '식수',
+                                text2: '식수 QR, 식수신청 등',
+                                route: '/restaurant_main'),
+                            MoveButton(
+                                icon: Icons.cut,
+                                text1: '미용실',
+                                text2: '미용실 예약, 가격표',
+                                route: '/salon_main'),
+                            MoveButton(
+                                icon: Icons.support_agent,
+                                text1: '행정',
+                                text2: '공지사항, AS 요청 등',
+                                route: '/admin_main'),
+                          ],
+                        ),
                       ),
                     ),
                   ),
@@ -79,11 +81,10 @@ class DashboardMain extends ConsumerWidget {
                   },
                   child: asyncNotice.when(
                     data: (notice) => MiniRoundedBox(
-                    
                       iconData: Icons.support_agent,
                       iconColor: Palette.stateColor1,
                       text: notice.title,
-                       // API로부터 받은 긴급 공지사항 제목
+                      // API로부터 받은 긴급 공지사항 제목
                     ),
                     loading: () => Center(
                         child: CircularProgressIndicator(

--- a/lib/restaurant/presentaion/pages/meal_application.dart
+++ b/lib/restaurant/presentaion/pages/meal_application.dart
@@ -637,24 +637,33 @@ class _MealApplicationState extends ConsumerState<MealApplication> {
           children: <Widget>[
             Text(
               '정말 취소 하시겠습니까?',
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
             SizedBox(height: 25),
           ],
         ),
         actions: [
-          ElevatedButton(
+          TextButton(
             onPressed: () async {
               Navigator.pop(context); // 다이얼로그를 닫습니다.
               await cancelMealApplication(); // 신청 취소 API 호출
             },
-            child: const Text('예'),
+            child: Text('예',
+                style: TextStyle(
+                    color: Palette.textColor,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 12)),
           ),
-          ElevatedButton(
+          TextButton(
             onPressed: () {
-              Navigator.pop(context); // 다이얼로그만 닫기
+              // 알림 창 닫기
+              Navigator.pop(context);
             },
-            child: const Text('아니오'),
+            child: Text('아니오',
+                style: TextStyle(
+                    color: Palette.stateColor3,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 12)),
           ),
         ],
       ),

--- a/lib/restaurant/presentaion/pages/weekend_meal.dart
+++ b/lib/restaurant/presentaion/pages/weekend_meal.dart
@@ -1122,7 +1122,7 @@ class _WeekendMealState extends State<WeekendMeal> {
           children: <Widget>[
             Text(
               '정말 취소 하시겠습니까?',
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
             SizedBox(
               height: 25,
@@ -1130,7 +1130,7 @@ class _WeekendMealState extends State<WeekendMeal> {
           ],
         ),
         actions: [
-          ElevatedButton(
+          TextButton(
             onPressed: () async {
               // 신청 취소 처리
               await deleteApplication(applicationId);
@@ -1144,14 +1144,18 @@ class _WeekendMealState extends State<WeekendMeal> {
               // 알림 창 닫기
               Navigator.pop(context);
             },
-            child: Text('예'),
+            child: Text('예', style: TextStyle(
+                                  color: Palette.textColor,
+                                  fontWeight: FontWeight.w600, fontSize: 12)),
           ),
-          ElevatedButton(
+          TextButton(
             onPressed: () {
               // 알림 창 닫기
               Navigator.pop(context);
             },
-            child: Text('아니오'),
+            child: Text('아니오',  style: TextStyle(
+                                  color: Palette.stateColor3,
+                                  fontWeight: FontWeight.w600, fontSize: 12)),
           ),
         ],
       ),

--- a/lib/salon/data/data_sources/admin/admin_reservation_data_source.dart
+++ b/lib/salon/data/data_sources/admin/admin_reservation_data_source.dart
@@ -37,6 +37,9 @@ class AdminReservationDataSource {
     try {
       final response = await dio.patch(url, data: data);
       return response;
+    } on DioException catch (e) {
+      debugPrint('코드: ${e.response!.statusCode} 데이터: ${e.response!.data}');
+      throw Exception('예약 상태 변경에 실패했습니다. : $e');
     } catch (e) {
       debugPrint('통신 결과: $e');
       throw Exception('예약 상태 변경에 실패했습니다.');

--- a/lib/salon/presentaion/widgets/time_slots_grid.dart
+++ b/lib/salon/presentaion/widgets/time_slots_grid.dart
@@ -23,15 +23,22 @@ class TimeSlotsGrid extends ConsumerWidget {
         itemBuilder: (context, index) {
           bool isSelected = timeSlots[index].time ==
               ref.watch(selectedTimeSlotProvider.notifier).state;
+          bool isAvailable = timeSlots[index].available == true;
           return Padding(
             padding: const EdgeInsets.all(3.0),
             child: ElevatedButton(
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.resolveWith<Color>(
-                  (Set<MaterialState> states) {
-                    return Palette.textColor.withOpacity(0.7);
-                  },
-                ),
+                backgroundColor: isAvailable == true
+                    ? MaterialStateProperty.all<Color>(Colors.white)
+                    : MaterialStateProperty.all<Color>(
+                        Palette.stateColor4.withOpacity(0.2)),
+                foregroundColor: isAvailable == true
+                    ? MaterialStateProperty.all<Color>(
+                        Palette.textColor.withOpacity(0.7))
+                    : MaterialStateProperty.all<Color>(
+                        Palette.stateColor4.withOpacity(0.9)),
+                overlayColor: MaterialStateProperty.all<Color>(
+                    Palette.stateColor1.withOpacity(0.3)),
                 shape: MaterialStateProperty.all<RoundedRectangleBorder>(
                   RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(5.0),
@@ -39,6 +46,7 @@ class TimeSlotsGrid extends ConsumerWidget {
                         BorderSide(color: Palette.stateColor4.withOpacity(0.4)),
                   ),
                 ),
+                elevation: MaterialStateProperty.all<double>(0),
               ),
               onPressed: timeSlots[index].available == true
                   ? () {
@@ -48,11 +56,13 @@ class TimeSlotsGrid extends ConsumerWidget {
 
                       bookingExecutionModal(context, ref);
                     }
-                  : null, // `timeSlots[index].available`이 false 또는 null일 때는 버튼 비활성화
-
-              child: Text(
-                timeSlots[index].time!,
-                style: TextStyle(fontSize: 12.0, letterSpacing: -0.5),
+                  : null,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  timeSlots[index].time!,
+                  style: TextStyle(fontSize: 12.0, letterSpacing: -0.5),
+                ),
               ),
             ),
           );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -661,30 +661,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.0"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -713,26 +689,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -753,10 +729,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   path_parsing:
     dependency: transitive
     description:
@@ -1146,14 +1122,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
-      url: "https://pub.dev"
-    source: hosted
-    version: "13.0.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## 📣 연관된 이슈
> X

## 📝 작업 내용
> 한국어
- 메인 대쉬보드에 있는 버튼 네비게이터에 MediaQuery를 적용하였습니다. (특정 디바이스에서 호환이 안 되어 버튼이 이탈하는 문제 수정)
- 미용실 예약 시 영업 시간 슬롯 버튼의 UI를 변경하였습니다.
- 회의실 예약 시 예외처리 버그를 발견하여 수정하였습니다.
- 그 외, 모달 디자인 통일 작업이 이루어졌습니다.

> 일본어
- メインダッシュボードのボタンナビゲーターにMediaQueryを適用しました。（特定のデバイスで互換性がなく、ボタンがずれる問題を修正）
- 美容室予約時の営業時間スロットボタンのUIを変更しました。
- 会議室予約時のエラーハンドリングのバグを発見し、修正しました。
- その他、モーダルデザインの統一作業を行いました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
