### PR TITLE
Feat: Auth関連ページおよび設定ページのローカライズ適用

### DIFF
--- a/assets/langs/ja.json
+++ b/assets/langs/ja.json
@@ -19,6 +19,59 @@
     }
   },
 
+  "registration" : {
+    "description": "情報を入力してください。",
+    "isSuccess": "登録が完了しました。",
+    "form": {
+      "name": "名前",
+      "email": "メールアドレス",
+      "password": "パスワード",
+      "phoneNumber": "電話番号",
+      "studentNumber": "学籍番号",
+      "registerButton": "登録",
+      "validatorText" : {
+        "isRequiredField": "必須項目です。",
+        "isEmail": "メールアドレスの形式が正しくありません。",
+        "isPasswordMinLength": "パスワードは8文字以上で入力してください。",
+        "name": "名前を入力してください。",
+        "email": "メールアドレスを入力してください。",
+        "emailExist": "このメールアドレスは既に登録されています。",
+        "emailNotExist": "このメールアドレスは登録されていません。",
+        "emailDuplicateCheck": "メールの重複チェックを行ってください。",
+        "password": "パスワードを入力してください。",
+        "phoneNumber": "電話番号を入力してください。",
+        "studentNumber": "学籍番号を入力してください。",
+        "emailFormat": "メールアドレスの形式が正しくありません。",
+        "phoneFormat": "電話番号の形式が正しくありません。",
+        "studentNumberFormat": "学籍番号の形式が正しくありません。",
+        "formInvalid": "全ての項目を入力してください。"
+      }
+    }
+  },
+
+  "forgotPassword": {
+    "verificationCode": "認証コード",
+    "isVerificationCodeEntered": "メールで受け取った6桁の認証コードを入力してください。",
+    "isVerificationCodeExpired" : "認証コードの有効期限が切れました。再送信してください。",
+    "resetPassword" : {
+      "description": "新しいパスワードを入力してください。",
+      "passwordResetSuccess": "パスワードがリセットされました。ログインしてください。",
+      "passwordResetFailed": "パスワードのリセットに失敗しました。再度お試しください。",
+      "form": {
+        "resetButton": "パスワードリセット",
+        "newPassword" : "新しいパスワード",
+        "newPasswordValidatorText" : "パスワードは8文字以上で入力してください。"
+      }
+    },
+    "form": {
+      "sendButton": "メール送信",
+      "resetButton": "パスワードリセット",
+      "isUserNotFound": "ユーザー情報が存在しません。再度ご確認ください。",
+      "isVerificationSuccessful" : "認証に成功しました。パスワードを再設定してください。",
+      "isVerificationCodeInvalid" : "認証番号が正しくありません。再度ご確認ください。"
+    }
+  },
+
   "mainDashboard": {
     "qrButton": {
       "bus": "バスQR",
@@ -143,6 +196,35 @@
         "approved": "承認",
         "unknown": "不明"
       }
+    }
+  },
+
+  "settings": {
+    "title": "設定",
+    "common": {
+      "title": "共通",
+      "language": {
+        "title": "言語",
+        "ko": "韓国語",
+        "ja": "日本語"
+      },
+      "notification": "通知"
+  },
+  "account": {
+    "title": "アカウント",
+    "informationUpdate": "情報更新",
+    "logout": "ログアウト",
+    "withdrawal": {
+      "title": "退会",
+      "withdrawalSuccess": "退会が完了しました。ログイン画面に戻ります。",
+      "withdrawalFailed": "退会に失敗しました。再度お試しください。",
+      "confirm": {
+        "title": "退会確認",
+        "description": "本当に退会しますか？退会後の復旧は不可能です。",
+        "yes": "はい",
+        "no": "いいえ"
+      }
+    }
     }
   },
 

--- a/assets/langs/ko.json
+++ b/assets/langs/ko.json
@@ -19,6 +19,59 @@
     }
   },
 
+  "registration" : {
+    "description": "情報を入力してください。",
+    "isSuccess": "登録が完了しました。",
+    "form": {
+      "name": "名前",
+      "email": "メールアドレス",
+      "password": "パスワード",
+      "phoneNumber": "電話番号",
+      "studentNumber": "学籍番号",
+      "registerButton": "登録",
+      "validatorText" : {
+        "isRequiredField": "必須項目です。",
+        "isEmail": "メールアドレスの形式が正しくありません。",
+        "isPasswordMinLength": "パスワードは8文字以上で入力してください。",
+        "name": "名前を入力してください。",
+        "email": "メールアドレスを入力してください。",
+        "emailExist": "このメールアドレスは既に登録されています。",
+        "emailNotExist": "このメールアドレスは登録されていません。",
+        "emailDuplicateCheck": "メールの重複チェックを行ってください。",
+        "password": "パスワードを入力してください。",
+        "phoneNumber": "電話番号を入力してください。",
+        "studentNumber": "学籍番号を入力してください。",
+        "emailFormat": "メールアドレスの形式が正しくありません。",
+        "phoneFormat": "電話番号の形式が正しくありません。",
+        "studentNumberFormat": "学籍番号の形式が正しくありません。",
+        "formInvalid": "全ての項目を入力してください。"
+      }
+    }
+  },
+
+  "forgotPassword": {
+    "verificationCode": "認証コード",
+    "isVerificationCodeEntered": "メールで受け取った6桁の認証コードを入力してください。",
+    "isVerificationCodeExpired" : "認証コードの有効期限が切れました。再送信してください。",
+    "resetPassword" : {
+      "description": "新しいパスワードを入力してください。",
+      "passwordResetSuccess": "パスワードがリセットされました。ログインしてください。",
+      "passwordResetFailed": "パスワードのリセットに失敗しました。再度お試しください。",
+      "form": {
+        "resetButton": "パスワードリセット",
+        "newPassword" : "新しいパスワード",
+        "newPasswordValidatorText" : "パスワードは8文字以上で入力してください。"
+      }
+    },
+    "form": {
+      "sendButton": "メール送信",
+      "resetButton": "パスワードリセット",
+      "isUserNotFound": "ユーザー情報が存在しません。再度ご確認ください。",
+      "isVerificationSuccessful" : "認証に成功しました。パスワードを再設定してください。",
+      "isVerificationCodeInvalid" : "認証番号が正しくありません。再度ご確認ください。"
+    }
+  },
+
   "mainDashboard": {
     "qrButton": {
       "bus": "バスQR",
@@ -143,6 +196,35 @@
         "approved": "承認",
         "unknown": "不明"
       }
+    }
+  },
+
+  "settings": {
+    "title": "設定",
+    "common": {
+      "title": "共通",
+      "language": {
+        "title": "言語",
+        "ko": "韓国語",
+        "ja": "日本語"
+      },
+      "notification": "通知"
+  },
+  "account": {
+    "title": "アカウント",
+    "informationUpdate": "情報更新",
+    "logout": "ログアウト",
+    "withdrawal": {
+      "title": "退会",
+      "withdrawalSuccess": "退会が完了しました。ログイン画面に戻ります。",
+      "withdrawalFailed": "退会に失敗しました。再度お試しください。",
+      "confirm": {
+        "title": "退会確認",
+        "description": "本当に退会しますか？退会後の復旧は不可能です。",
+        "yes": "はい",
+        "no": "いいえ"
+      }
+    }
     }
   },
 

--- a/lib/auth/data/data_resources/reset_password_data_source.dart
+++ b/lib/auth/data/data_resources/reset_password_data_source.dart
@@ -52,7 +52,7 @@ class ResetPasswordDataSource {
     };
 
     try {
-      final response = await dio.get(
+      final response = await dio.post(
         url,
         queryParameters: queryParams,
         options: Options(extra: {"noAuth": true}),
@@ -62,6 +62,9 @@ class ResetPasswordDataSource {
       await storage.write(key: 'auth_token', value: token);
 
       return response;
+    } on DioException catch (e) {
+      debugPrint('${e.response}, 코드: ${e.response?.statusCode}');
+      throw Exception('인증번호 검증에 실패했습니다.');
     } catch (e) {
       debugPrint('통신 결과: $e');
       throw Exception('인증번호 검증에 실패했습니다.');

--- a/lib/auth/domain/usecases/register_usecase.dart
+++ b/lib/auth/domain/usecases/register_usecase.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -34,7 +35,7 @@ class RegisterUseCase {
       await RegisterDataSource().postRegisterAPI(ref);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-            content: Text('회원가입에 성공하였습니다.'),
+            content: Text('registration.isSuccess'.tr()),
             backgroundColor: Palette.mainColor),
       );
       // 성공 시 로그인 페이지로 이동(이전 페이지로 못 가게 막아버림)

--- a/lib/auth/domain/usecases/reset_password_new_usecase.dart
+++ b/lib/auth/domain/usecases/reset_password_new_usecase.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/auth/data/data_resources/reset_password_data_source.dart';
@@ -24,7 +25,7 @@ class ResetPasswordNewUseCase {
       await dataSource.patchNewPasswordAPI(ref);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('비밀번호가 변경되었습니다. 로그인 해 주세요.'),
+          content: Text('forgotPassword.resetPassword.passwordResetSuccess').tr(),
           backgroundColor: Palette.mainColor,
         ),
       );
@@ -34,7 +35,7 @@ class ResetPasswordNewUseCase {
       // 회원가입 실패 시 에러 메시지 표시
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('비밀번호 변경에 실패했습니다. 다시 시도해 주세요.'),
+          content: Text('forgotPassword.resetPassword.passwordResetFailed').tr(),
           backgroundColor: Colors.red,
         ),
       );

--- a/lib/auth/domain/usecases/reset_password_usecase.dart
+++ b/lib/auth/domain/usecases/reset_password_usecase.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/auth/data/data_resources/reset_password_data_source.dart';
@@ -30,7 +31,7 @@ class ResetPasswordUseCase {
       // 회원가입 실패 시 에러 메시지 표시
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('유저 정보가 존재하지 않습니다. 다시 한 번 확인해 주세요.'),
+          content: Text('forgotPassword.form.isUserNotFound'.tr()),
           backgroundColor: Colors.red,
         ),
       );

--- a/lib/auth/domain/usecases/reset_password_verify_code_usecase.dart
+++ b/lib/auth/domain/usecases/reset_password_verify_code_usecase.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yjg/auth/data/data_resources/reset_password_data_source.dart';
@@ -21,7 +22,7 @@ class ResetPasswordVerifyCodeUseCase {
       await dataSource.postResetPasswordMailVerifyAPI(ref);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-            content: Text('인증에 성공했습니다. 비밀번호를 재설정해 주세요.'),
+            content: Text('forgotPassword.form.isVerificationSuccessful').tr(),
             backgroundColor: Palette.mainColor),
       );
       Navigator.pushNamed(context, '/new_password');
@@ -29,7 +30,7 @@ class ResetPasswordVerifyCodeUseCase {
       // 회원가입 실패 시 에러 메시지 표시
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('인증번호가 올바르지 않습니다. 다시 한 번 확인해 주세요.'),
+          content: Text('forgotPassword.form.isVerificationCodeInvalid').tr(),
           backgroundColor: Colors.red,
         ),
       );

--- a/lib/auth/presentation/pages/international_registration.dart
+++ b/lib/auth/presentation/pages/international_registration.dart
@@ -1,3 +1,4 @@
+import "package:easy_localization/easy_localization.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:yjg/auth/domain/usecases/register_usecase.dart";
@@ -34,8 +35,8 @@ class InternationalRegisteration extends ConsumerWidget {
               ),
               Padding(
                 padding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0),
-                child: const Text(
-                  '정보를 입력해 주세요.',
+                child: Text(
+                  'registration.description'.tr(),
                   style: TextStyle(fontSize: 18.0, color: Palette.textColor),
                 ),
               ),
@@ -54,8 +55,9 @@ class InternationalRegisteration extends ConsumerWidget {
                             horizontal: 8, vertical: 14),
                         child: AuthTextFormField(
                           controller: nameController,
-                          labelText: "이름",
-                          validatorText: "이름을 입력해 주세요.",
+                          labelText: "registration.form.name".tr(),
+                          validatorText:
+                              "registration.form.validatorText.name".tr(),
                         ),
                       ),
                       Padding(
@@ -63,8 +65,9 @@ class InternationalRegisteration extends ConsumerWidget {
                             horizontal: 8, vertical: 14),
                         child: AuthTextFormField(
                           controller: emailController,
-                          labelText: "이메일",
-                          validatorText: "이메일을 입력해 주세요.",
+                          labelText: "registration.form.email".tr(),
+                          validatorText:
+                              "registration.form.validatorText.email".tr(),
                           suffixIcon: IconButton(
                             icon: Icon(Icons.check_circle_outline),
                             onPressed: () async {
@@ -85,7 +88,9 @@ class InternationalRegisteration extends ConsumerWidget {
                                   ScaffoldMessenger.of(context).showSnackBar(
                                     SnackBar(
                                       backgroundColor: Palette.mainColor,
-                                      content: Text('사용 가능한 이메일입니다.'),
+                                      content: Text(
+                                          'registration.form.validatorText.emailNotExist'
+                                              .tr()),
                                       duration: Duration(seconds: 2),
                                     ),
                                   );
@@ -94,7 +99,9 @@ class InternationalRegisteration extends ConsumerWidget {
                                   ScaffoldMessenger.of(context).showSnackBar(
                                     SnackBar(
                                       backgroundColor: Colors.red,
-                                      content: Text('이미 사용중인 이메일입니다.'),
+                                      content: Text(
+                                          'registration.form.validatorText.emailExist'
+                                              .tr()),
                                       duration: Duration(seconds: 2),
                                     ),
                                   );
@@ -103,7 +110,9 @@ class InternationalRegisteration extends ConsumerWidget {
                                 // 필요한 경우 사용자에게 알림 표시
                                 ScaffoldMessenger.of(context).showSnackBar(
                                   SnackBar(
-                                    content: Text('이메일 주소를 입력해주세요.'),
+                                    content: Text(
+                                        'registration.form.validatorText.email'
+                                            .tr()),
                                     duration: Duration(seconds: 2),
                                   ),
                                 );
@@ -118,8 +127,9 @@ class InternationalRegisteration extends ConsumerWidget {
                             horizontal: 8, vertical: 14),
                         child: AuthTextFormField(
                           controller: passwordController,
-                          labelText: "비밀번호",
-                          validatorText: "비밀번호를 입력해 주세요.",
+                          labelText: "registration.form.password".tr(),
+                          validatorText:
+                              "registration.form.validatorText.password".tr(),
                         ),
                       ),
                       Padding(
@@ -127,8 +137,10 @@ class InternationalRegisteration extends ConsumerWidget {
                             horizontal: 8, vertical: 14),
                         child: AuthTextFormField(
                           controller: studentIdController,
-                          labelText: "학번",
-                          validatorText: "학번을 입력해 주세요.",
+                          labelText: "registration.form.studentNumber".tr(),
+                          validatorText:
+                              "registration.form.validatorText.studentNumber"
+                                  .tr(),
                         ),
                       ),
                       Padding(
@@ -136,8 +148,10 @@ class InternationalRegisteration extends ConsumerWidget {
                             horizontal: 8, vertical: 14),
                         child: AuthTextFormField(
                           controller: phoneNumberController,
-                          labelText: "전화번호",
-                          validatorText: "전화번호를 입력해 주세요.",
+                          labelText: "registration.form.phoneNumber".tr(),
+                          validatorText:
+                              "registration.form.validatorText.phoneNumber"
+                                  .tr(),
                           inputFormatter: PhoneNumberInputFormatter(),
                         ),
                       ),
@@ -156,8 +170,10 @@ class InternationalRegisteration extends ConsumerWidget {
                               debugPrint('체크:  $emailCheckSuccess');
                               if (!emailCheckSuccess) {
                                 ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text('이메일 중복 검사를 해주세요.'),
+                                  SnackBar(
+                                    content: Text(
+                                        'registration.form.validatorText.emailDuplicateCheck'
+                                            .tr()),
                                     backgroundColor: Colors.red,
                                   ),
                                 );
@@ -183,9 +199,10 @@ class InternationalRegisteration extends ConsumerWidget {
                               } else {
                                 // Form이 유효하지 않은 경우, 사용자에게 알림
                                 ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
+                                  SnackBar(
                                     content: Text(
-                                        '입력되지 않은 필드가 있습니다. 다시 한 번 확인해 주세요.'),
+                                        'registration.form.validatorText.formInvalid'
+                                            .tr()),
                                     backgroundColor: Palette.mainColor,
                                   ),
                                 );
@@ -218,8 +235,8 @@ class InternationalRegisteration extends ConsumerWidget {
                               fixedSize: MaterialStateProperty.all<Size>(
                                   Size(100, 40)),
                             ),
-                            child: const Text(
-                              '회원가입',
+                            child: Text(
+                              'registration.form.registerButton'.tr(),
                               style: TextStyle(fontWeight: FontWeight.bold),
                             ),
                           ),

--- a/lib/auth/presentation/pages/mail_verification_code.dart
+++ b/lib/auth/presentation/pages/mail_verification_code.dart
@@ -1,3 +1,4 @@
+import "package:easy_localization/easy_localization.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:timer_count_down/timer_count_down.dart";
@@ -28,9 +29,9 @@ class MailVerficationCode extends ConsumerWidget {
               ),
               Padding(
                 padding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0),
-                child: const Text(
-                  '메일로 받은 인증코드 6자리를 입력해 주세요.',
-                  style: TextStyle(fontSize: 16.0, color: Palette.textColor),
+                child: Text(
+                  'forgotPassword.isVerificationCodeEntered'.tr(),
+                  style: TextStyle(fontSize: 14.0, color: Palette.textColor),
                 ),
               ),
               Countdown(
@@ -45,7 +46,7 @@ class MailVerficationCode extends ConsumerWidget {
                   // 인증 코드 재전송 로직 구현
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
-                      content: Text('인증 코드가 만료되었습니다. 다시 전송해 주세요.'),
+                      content: Text('forgotPassword.isVerificationCodeExpired').tr(),
                       backgroundColor: Colors.red,
                     ),
                   );
@@ -67,8 +68,8 @@ class MailVerficationCode extends ConsumerWidget {
                             horizontal: 8, vertical: 14),
                         child: AuthTextFormField(
                           controller: nameVerficationCodeController,
-                          labelText: "인증 코드",
-                          validatorText: "인증 코드 6자리를 입력해 주세요.",
+                          labelText: "forgotPassword.verificationCode".tr(),
+                          validatorText: "forgotPassword.isVerificationCodeEntered".tr(),
                         ),
                       ),
                       Padding(
@@ -91,9 +92,9 @@ class MailVerficationCode extends ConsumerWidget {
                               } else {
                                 // Form이 유효하지 않은 경우, 사용자에게 알림
                                 ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
+                                 SnackBar(
                                     content: Text(
-                                        '입력되지 않은 필드가 있습니다. 다시 한 번 확인해 주세요.'),
+                                        'registration.form.validatorText.formInvalid').tr(),
                                     backgroundColor: Palette.mainColor,
                                   ),
                                 );
@@ -126,8 +127,8 @@ class MailVerficationCode extends ConsumerWidget {
                               fixedSize: MaterialStateProperty.all<Size>(
                                   Size(100, 40)),
                             ),
-                            child: const Text(
-                              '인증 완료',
+                            child: Text(
+                              'forgotPassword.form.resetButton'.tr(),
                               style: TextStyle(fontWeight: FontWeight.bold),
                             ),
                           ),

--- a/lib/auth/presentation/pages/new_password_update.dart
+++ b/lib/auth/presentation/pages/new_password_update.dart
@@ -1,3 +1,4 @@
+import "package:easy_localization/easy_localization.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:yjg/auth/domain/usecases/reset_password_new_usecase.dart";
@@ -27,8 +28,8 @@ class newPasswordUpdate extends ConsumerWidget {
               ),
               Padding(
                 padding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0),
-                child: const Text(
-                  '새로운 비밀번호를 입력해 주세요.',
+                child: Text(
+                  'forgotPassword.resetPassword.description'.tr(),
                   style: TextStyle(fontSize: 18.0, color: Palette.textColor),
                 ),
               ),
@@ -47,8 +48,12 @@ class newPasswordUpdate extends ConsumerWidget {
                             horizontal: 8, vertical: 14),
                         child: AuthTextFormField(
                           controller: passwordController,
-                          labelText: "비밀번호",
-                          validatorText: "새로운 비밀번호를 입력해 주세요.",
+                          labelText:
+                              "forgotPassword.resetPassword.form.newPassword"
+                                  .tr(),
+                          validatorText:
+                              "forgotPassword.resetPassword.form.newPasswordvalidatorText"
+                                  .tr(),
                         ),
                       ),
                       Padding(
@@ -75,9 +80,10 @@ class newPasswordUpdate extends ConsumerWidget {
                               } else {
                                 // Form이 유효하지 않은 경우, 사용자에게 알림
                                 ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
+                                  SnackBar(
                                     content: Text(
-                                        '입력되지 않은 필드가 있습니다. 다시 한 번 확인해 주세요.'),
+                                        'registration.form.validatorText.formInvalid'
+                                            .tr()),
                                     backgroundColor: Palette.mainColor,
                                   ),
                                 );
@@ -110,8 +116,9 @@ class newPasswordUpdate extends ConsumerWidget {
                               fixedSize: MaterialStateProperty.all<Size>(
                                   Size(100, 40)),
                             ),
-                            child: const Text(
-                              '비밀번호 변경',
+                            child: Text(
+                              'forgotPassword.resetPassword.form.resetButton'
+                                  .tr(),
                               style: TextStyle(fontWeight: FontWeight.bold),
                             ),
                           ),

--- a/lib/auth/presentation/pages/reset_password.dart
+++ b/lib/auth/presentation/pages/reset_password.dart
@@ -1,3 +1,4 @@
+import "package:easy_localization/easy_localization.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:yjg/auth/domain/usecases/reset_password_usecase.dart";
@@ -28,8 +29,8 @@ class ResetPassword extends ConsumerWidget {
               ),
               Padding(
                 padding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0),
-                child: const Text(
-                  '정보를 입력해 주세요.',
+                child: Text(
+                  'registration.description'.tr(),
                   style: TextStyle(fontSize: 18.0, color: Palette.textColor),
                 ),
               ),
@@ -48,8 +49,9 @@ class ResetPassword extends ConsumerWidget {
                             horizontal: 8, vertical: 14),
                         child: AuthTextFormField(
                           controller: nameController,
-                          labelText: "이름",
-                          validatorText: "이름을 입력해 주세요.",
+                          labelText: "registration.form.name".tr(),
+                          validatorText:
+                              "registration.form.validatorText.name".tr(),
                         ),
                       ),
                       Padding(
@@ -57,8 +59,9 @@ class ResetPassword extends ConsumerWidget {
                             horizontal: 8, vertical: 14),
                         child: AuthTextFormField(
                           controller: emailController,
-                          labelText: "이메일",
-                          validatorText: "이메일을 입력해 주세요.",
+                          labelText: "registration.form.email".tr(),
+                          validatorText:
+                              "registration.form.validatorText.email".tr(),
                         ),
                         // 중복 검사 결과 표시
                       ),
@@ -72,23 +75,25 @@ class ResetPassword extends ConsumerWidget {
                           child: ElevatedButton(
                             onPressed: () async {
                               if (_formKey.currentState!.validate()) {
-                                try{
-                                final resetPasswordUsecase = ResetPasswordUseCase(ref: ref);
+                                try {
+                                  final resetPasswordUsecase =
+                                      ResetPasswordUseCase(ref: ref);
 
-                                await resetPasswordUsecase.execute(
-                                  email: emailController.text,
-                                  name: nameController.text,
-                                  context: context,
-                                );
+                                  await resetPasswordUsecase.execute(
+                                    email: emailController.text,
+                                    name: nameController.text,
+                                    context: context,
+                                  );
                                 } catch (e) {
                                   debugPrint('비밀번호 찾기 실패: $e');
                                 }
                               } else {
                                 // Form이 유효하지 않은 경우, 사용자에게 알림
                                 ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
+                                  SnackBar(
                                     content: Text(
-                                        '입력되지 않은 필드가 있습니다. 다시 한 번 확인해 주세요.'),
+                                        'registration.form.validatorText.formInvalid'
+                                            .tr()),
                                     backgroundColor: Palette.mainColor,
                                   ),
                                 );
@@ -121,8 +126,8 @@ class ResetPassword extends ConsumerWidget {
                               fixedSize: MaterialStateProperty.all<Size>(
                                   Size(100, 40)),
                             ),
-                            child: const Text(
-                              '메일 받기',
+                            child: Text(
+                              'forgotPassword.form.sendButton'.tr(),
                               style: TextStyle(fontWeight: FontWeight.bold),
                             ),
                           ),

--- a/lib/auth/presentation/widgets/auth_text_form_field.dart
+++ b/lib/auth/presentation/widgets/auth_text_form_field.dart
@@ -1,3 +1,4 @@
+import "package:easy_localization/easy_localization.dart";
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -29,7 +30,7 @@ class AuthTextFormField extends ConsumerWidget {
       height: height * 0.08,
       child: TextFormField(
         // 라벨텍스트에 비밀번호라는 글자가 포함되어 있으면 obscureText를 true로 설정
-        obscureText: labelText.contains("비밀번호") ? true : false,
+        obscureText: labelText.contains("login.sharedForm.password".tr()) ? true : false,
         controller: controller,
         decoration: InputDecoration(
           focusedBorder: OutlineInputBorder(
@@ -48,18 +49,18 @@ class AuthTextFormField extends ConsumerWidget {
         validator: (value) {
           // 공통: 필수 입력값 검사
           if (value == null || value.isEmpty) {
-            return '필수 입력 항목입니다.';
+            return 'registration.form.validatorText.isRequiredField'.tr();
           }
 
           // 이메일 유효성 검사
-          if (labelText == "이메일" &&
+          if (labelText == "registration.form.email".tr() &&
               !RegExp(r'\b[\w\.-]+@[\w\.-]+\.\w{2,4}\b').hasMatch(value)) {
-            return '유효한 이메일 주소를 입력해주세요.';
+            return 'registration.form.validatorText.isEmail'.tr();
           }
 
           // 비밀번호 유효성 검사
-          if (labelText == "비밀번호" && value.length < 8) {
-            return '비밀번호는 최소 8자 이상이어야 합니다.';
+          if ((labelText == "login.sharedForm.password".tr() )&& value.length < 8) {
+            return 'registration.form.validatorText.isPasswordMinLength'.tr();
           }
           return null;
           // 유효성 검사를 통과했다면 null 반환

--- a/lib/setting/presentation/pages/setting_page.dart
+++ b/lib/setting/presentation/pages/setting_page.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:settings_ui/settings_ui.dart';
@@ -48,7 +49,7 @@ class _SettingPageState extends ConsumerState<SettingPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: BaseAppBar(
-        title: '설정',
+        title: 'settings.title'.tr(),
       ),
       drawer: BaseDrawer(),
       bottomNavigationBar: const CustomBottomNavigationBar(),
@@ -56,7 +57,7 @@ class _SettingPageState extends ConsumerState<SettingPage> {
         sections: [
           SettingsSection(
             title: Text(
-              '공통',
+              'settings.common.title'.tr(),
               style: TextStyle(letterSpacing: -0.5),
             ),
             tiles: <SettingsTile>[
@@ -64,11 +65,11 @@ class _SettingPageState extends ConsumerState<SettingPage> {
               SettingsTile.navigation(
                 leading: Icon(Icons.language),
                 title: Text(
-                  '언어',
+                  'settings.common.language.title'.tr(),
                   style: TextStyle(letterSpacing: -0.5, fontSize: 15.0),
                 ),
                 value: Text(
-                  '한국어',
+                  'settings.common.language.ko'.tr(),
                   style: TextStyle(letterSpacing: -0.5, fontSize: 16.0),
                 ),
                 onPressed: ((context) {}),
@@ -76,7 +77,7 @@ class _SettingPageState extends ConsumerState<SettingPage> {
               SettingsTile.switchTile(
                 activeSwitchColor: Palette.mainColor,
                 title: Text(
-                  '알림',
+                  'settings.common.notification'.tr(),
                   style: TextStyle(letterSpacing: -0.5, fontSize: 15.0),
                 ),
                 initialValue: widget.notifications,
@@ -97,14 +98,14 @@ class _SettingPageState extends ConsumerState<SettingPage> {
           ),
           SettingsSection(
             title: Text(
-              '계정',
+              'settings.account.title'.tr(),
               style: TextStyle(letterSpacing: -0.5),
             ),
             tiles: <SettingsTile>[
               SettingsTile.navigation(
                 leading: Icon(Icons.logout),
                 title: Text(
-                  '로그아웃',
+                  'settings.account.logout'.tr(),
                   style: TextStyle(letterSpacing: -0.5, fontSize: 15.0),
                 ),
                 onPressed: ((context) {
@@ -114,7 +115,7 @@ class _SettingPageState extends ConsumerState<SettingPage> {
               SettingsTile.navigation(
                 leading: Icon(Icons.manage_accounts),
                 title: Text(
-                  '개인정보 수정',
+                  'settings.account.informationUpdate'.tr(),
                   style: TextStyle(letterSpacing: -0.5, fontSize: 15.0),
                 ),
                 onPressed: ((context) {
@@ -126,7 +127,7 @@ class _SettingPageState extends ConsumerState<SettingPage> {
               SettingsTile.navigation(
                 leading: Icon(Icons.person_remove),
                 title: Text(
-                  '회원탈퇴',
+                  'settings.account.withdrawal.title'.tr(),
                   style: TextStyle(
                     letterSpacing: -0.5,
                     fontSize: 15.0,
@@ -136,23 +137,23 @@ class _SettingPageState extends ConsumerState<SettingPage> {
                   final confirmDelete = await showDialog<bool>(
                     context: context,
                     builder: (context) => AlertDialog(
-                      title: Text('회원탈퇴',
+                      title: Text('settings.account.withdrawal.confirm.title'.tr(),
                           style: TextStyle(
                               color: Palette.textColor,
                               fontSize: 16.0,
                               fontWeight: FontWeight.w600)),
-                      content: Text('정말 회원탈퇴 하시겠습니까? 탈퇴 후 복구가 불가능합니다.'),
+                      content: Text('settings.account.withdrawal.confirm.description').tr(),
                       actions: <Widget>[
                         TextButton(
                           onPressed: () => Navigator.of(context).pop(false),
-                          child: Text('취소',
+                          child: Text('settings.account.withdrawal.confirm.no'.tr(),
                               style: TextStyle(
                                   color: Palette.stateColor4,
                                   fontWeight: FontWeight.w600)),
                         ),
                         TextButton(
                           onPressed: () => Navigator.of(context).pop(true),
-                          child: Text('삭제',
+                          child: Text('settings.account.withdrawal.confirm.yes'.tr(),
                               style: TextStyle(
                                   color: Palette.stateColor3,
                                   fontWeight: FontWeight.w600)),
@@ -167,7 +168,7 @@ class _SettingPageState extends ConsumerState<SettingPage> {
                       if (context.mounted) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: Text('회원탈퇴에 성공하였습니다. 로그아웃됩니다.'),
+                            content: Text('settings.account.withdrawal.withdrawalSuccess').tr(),
                             backgroundColor: Palette.mainColor,
                           ),
                         );
@@ -179,7 +180,7 @@ class _SettingPageState extends ConsumerState<SettingPage> {
                       if (context.mounted) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: Text('회원탈퇴 실패. 다시 시도해 주세요. 에러: $e'),
+                            content: Text('settings.account.withdrawal.withdrawalFailed').tr(),
                             backgroundColor: Colors.red,
                           ),
                         );


### PR DESCRIPTION
## 📣 연관된 이슈
> #260 

## 📝 작업 내용
> 한국어
1. 비밀번호 재설정, 회원가입 등 Auth 관련 페이지에 로컬라이즈를 적용하였습니다.
2. 설정 페이지에 로컬라이즈를 적용하였습니다.

> 日本語
1. パスワードのリセット、会員登録などの認証関連ページにローカライズを適用しました。
2. 設定ページにローカライズを適用しました。

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
